### PR TITLE
add AGENTS.md and CLAUDE.md symlink for agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,61 +1,94 @@
 # AGENTS.md
 
-This repository captures reusable skills for AI coding agents, following the [agent skills standard](https://claude.ai/code). Skills are self-contained Markdown files that agents can invoke to perform common, well-defined tasks.
+This repository captures reusable skills for AI coding agents. Agent guidance follows the [AGENTS.md standard](https://agents.md); skill format follows the [Agent Skills standard](https://agentskills.io).
 
 ## Repository Purpose
 
 - Store reusable, composable skills for use with Claude Code and other AI coding agents
 - Provide clear, consistent conventions so agents can discover and apply skills reliably
-- Serve as a reference implementation of the agent skills standard
+- Follow the [agentskills.io](https://agentskills.io) open standard for skill format and discovery
 
 ## Structure
 
 ```
 skills/
-├── AGENTS.md          # This file — agent guidance for the repo
-├── CLAUDE.md          # Symlink → AGENTS.md (Claude Code compatibility)
+├── AGENTS.md              # This file — agent guidance (agents.md standard)
+├── CLAUDE.md              # Symlink → AGENTS.md (Claude Code compatibility)
 ├── LICENSE
-└── <skill-name>.md    # Each skill is a single Markdown file
+└── <skill-name>/          # Each skill is a directory
+    ├── SKILL.md           # Required: YAML frontmatter + instructions
+    ├── scripts/           # Optional: executable scripts (Python, Bash, JS)
+    ├── references/        # Optional: reference materials, API docs, schemas
+    └── assets/            # Optional: templates, examples, other resources
 ```
 
 ## Skills Format
 
-Each skill file (`<skill-name>.md`) follows this structure:
+Each skill is a **directory** named after the skill. The directory must contain a `SKILL.md` file with YAML frontmatter followed by Markdown instructions. See the [Agent Skills specification](https://agentskills.io/specification) for full details.
+
+### Frontmatter
+
+```yaml
+---
+name: skill-name          # required: must match the directory name
+description: >            # required: what this skill does and when to use it
+  Extracts and summarizes content from PDF files. Use when the user
+  asks to read, parse, or extract text from a PDF document.
+license: Apache-2.0       # optional
+metadata:                 # optional: version tracking, authorship
+  author: your-handle
+  version: "1.0"
+allowed-tools:            # optional: restrict which tools the skill may use
+  - Bash
+  - Read
+---
+```
+
+**`name`** rules:
+- Lowercase letters, numbers, and hyphens only
+- 1–64 characters; no leading/trailing/consecutive hyphens
+- Must match the parent directory name exactly
+
+**`description`** rules:
+- Non-empty, maximum 1024 characters
+- Write in third person — this text is injected into the system prompt for discovery
+- Include both *what* the skill does and *when* to invoke it
+
+### Markdown body
+
+Write whatever helps agents perform the task effectively. Recommended sections:
 
 ```markdown
----
-description: One-line description of what the skill does and when to invoke it
----
-
-# <Skill Name>
+# Skill Name
 
 Brief overview of the skill's purpose.
 
-## Usage
+## Instructions
 
-How the skill is invoked and any arguments it accepts.
-
-## Steps
-
-Numbered or bulleted steps the agent should follow.
+Step-by-step guidance for the agent to follow.
 
 ## Examples
 
-Concrete examples demonstrating the skill in action.
+Concrete examples with inputs and expected outputs.
 ```
 
-Key conventions:
-- Filenames are lowercase, hyphen-separated (e.g., `review-pr.md`, `commit.md`)
-- Each skill is self-contained — no cross-file dependencies unless explicitly stated
-- Steps should be actionable and unambiguous; prefer commands over prose
-- Include real examples over abstract descriptions
+### Progressive disclosure
+
+Skills load in three stages — keep each lean:
+
+| Level | Content | When loaded | Target size |
+|-------|---------|-------------|-------------|
+| 1 | `name` + `description` frontmatter | Always (startup) | ~100 tokens |
+| 2 | `SKILL.md` body | When skill is triggered | < 5,000 tokens |
+| 3 | `scripts/`, `references/`, `assets/` | On demand, via bash | Unlimited |
 
 ## Adding a New Skill
 
-1. Create `<skill-name>.md` at the repo root
-2. Add a `description:` frontmatter field — this is what agents use to match triggers
-3. Write clear, concrete steps (executable commands > paragraphs)
-4. Commit with a descriptive message: `add <skill-name> skill: <one-line summary>`
+1. Create a directory: `<skill-name>/` (lowercase, hyphen-separated)
+2. Add `<skill-name>/SKILL.md` with `name:` and `description:` frontmatter
+3. Write clear, concrete instructions in the Markdown body
+4. Add `scripts/`, `references/`, or `assets/` as needed for Level 3 content
+5. Commit: `add <skill-name> skill: <one-line summary>`
 
 ## Git Workflow
 
@@ -66,13 +99,15 @@ Key conventions:
 
 ## Code Style & Conventions
 
-- Markdown: use ATX headings (`#`), fenced code blocks with language tags
+- Markdown: ATX headings (`#`), fenced code blocks with language tags
 - Frontmatter: YAML, delimited by `---`
-- Keep skill files focused — one skill per file, no bundling unrelated tasks
+- One skill per directory; do not bundle unrelated tasks
 - Prefer explicit over implicit; agents should not need to infer intent
+- Scripts should be self-contained or clearly document their dependencies
 
 ## Security
 
 - Never commit secrets, tokens, or credentials
-- Skills that touch external services must document required environment variables
+- Skills that touch external services must document required environment variables in their `SKILL.md`
 - Do not add skills that perform destructive operations without explicit confirmation steps
+- Only use skills from trusted sources — treat them like installed software

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+This repository captures reusable skills for AI coding agents, following the [agent skills standard](https://claude.ai/code). Skills are self-contained Markdown files that agents can invoke to perform common, well-defined tasks.
+
+## Repository Purpose
+
+- Store reusable, composable skills for use with Claude Code and other AI coding agents
+- Provide clear, consistent conventions so agents can discover and apply skills reliably
+- Serve as a reference implementation of the agent skills standard
+
+## Structure
+
+```
+skills/
+├── AGENTS.md          # This file — agent guidance for the repo
+├── CLAUDE.md          # Symlink → AGENTS.md (Claude Code compatibility)
+├── LICENSE
+└── <skill-name>.md    # Each skill is a single Markdown file
+```
+
+## Skills Format
+
+Each skill file (`<skill-name>.md`) follows this structure:
+
+```markdown
+---
+description: One-line description of what the skill does and when to invoke it
+---
+
+# <Skill Name>
+
+Brief overview of the skill's purpose.
+
+## Usage
+
+How the skill is invoked and any arguments it accepts.
+
+## Steps
+
+Numbered or bulleted steps the agent should follow.
+
+## Examples
+
+Concrete examples demonstrating the skill in action.
+```
+
+Key conventions:
+- Filenames are lowercase, hyphen-separated (e.g., `review-pr.md`, `commit.md`)
+- Each skill is self-contained — no cross-file dependencies unless explicitly stated
+- Steps should be actionable and unambiguous; prefer commands over prose
+- Include real examples over abstract descriptions
+
+## Adding a New Skill
+
+1. Create `<skill-name>.md` at the repo root
+2. Add a `description:` frontmatter field — this is what agents use to match triggers
+3. Write clear, concrete steps (executable commands > paragraphs)
+4. Commit with a descriptive message: `add <skill-name> skill: <one-line summary>`
+
+## Git Workflow
+
+- Default branch: `main`
+- Feature branches: `<author>/<short-description>` or `claude/<task-slug>`
+- Commit messages: imperative mood, lowercase, no trailing period
+- Do not force-push to `main`
+
+## Code Style & Conventions
+
+- Markdown: use ATX headings (`#`), fenced code blocks with language tags
+- Frontmatter: YAML, delimited by `---`
+- Keep skill files focused — one skill per file, no bundling unrelated tasks
+- Prefer explicit over implicit; agents should not need to infer intent
+
+## Security
+
+- Never commit secrets, tokens, or credentials
+- Skills that touch external services must document required environment variables
+- Do not add skills that perform destructive operations without explicit confirmation steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Sets up cross-tool agent configuration following the AGENTS.md open standard.
CLAUDE.md is a symlink to AGENTS.md so Claude Code and other tools both resolve
to the same guidance. Documents the skills repo purpose, skill file format,
conventions, and git workflow.

https://claude.ai/code/session_01QdCu4DNGoi6zh8DdoJuKPe