### PR TITLE
remove CLAUDE.md symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
## Summary

- Removes the `CLAUDE.md → AGENTS.md` symlink since Claude Code reads `AGENTS.md` directly when no `CLAUDE.md` is present, making the symlink redundant.

https://claude.ai/code/session_01QdCu4DNGoi6zh8DdoJuKPe