### PR TITLE
remove CLAUDE.md reference from AGENTS.md structure diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,6 @@ This repository captures reusable skills for AI coding agents. Agent guidance fo
 ```
 skills/
 ├── AGENTS.md              # This file — agent guidance (agents.md standard)
-├── CLAUDE.md              # Symlink → AGENTS.md (Claude Code compatibility)
 ├── LICENSE
 └── .agents/
     └── skills/


### PR DESCRIPTION
## Summary

- Removes the `CLAUDE.md` entry from the structure diagram in `AGENTS.md`, following the removal of the symlink in #3.

https://claude.ai/code/session_01QdCu4DNGoi6zh8DdoJuKPe