### PR TITLE
add skills skill: create, update, and manage skills with progressive disclosure

### DIFF
--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -51,6 +51,6 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 |-------|---------|--------------|
 | 1 | `name` + `description` | Always |
 | 2 | `SKILL.md` body (this file) | When skill is triggered |
-| 3 | `references/` files | When you need format details or examples |
+| 3 | `scripts/`, `references/`, `assets/` | When you need format details, examples, or executables |
 
 Read `references/skill-format.md` for complete frontmatter rules, naming constraints, and a full worked example.

--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: skills
+description: >
+  Creates, updates, and manages reusable agent skills in this repository.
+  Use when the user asks to add a new skill, modify an existing skill,
+  delete a skill, or review the skill structure and conventions.
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Skills
+
+Manages the lifecycle of reusable skills stored under `.agents/skills/`.
+
+## Instructions
+
+### Creating a skill
+
+1. Choose a name: lowercase letters, numbers, and hyphens only; 1–64 chars; must be unique under `.agents/skills/`
+2. Create the directory: `.agents/skills/<skill-name>/`
+3. Create `SKILL.md` — required frontmatter fields: `name` (must match directory), `description` (what it does and when to use it)
+4. Write a clear Markdown body with instructions agents can follow directly
+5. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
+6. Commit: `add <skill-name> skill: <one-line summary>`
+
+### Updating a skill
+
+1. Read the existing `SKILL.md` before making changes
+2. Keep the `name` field in sync with the directory name — never rename one without the other
+3. Update `metadata.version` when the instructions change meaningfully
+4. Commit: `update <skill-name> skill: <one-line summary of change>`
+
+### Deleting a skill
+
+1. Confirm with the user before deleting
+2. Remove the entire `.agents/skills/<skill-name>/` directory
+3. Commit: `remove <skill-name> skill: <reason>`
+
+### Reviewing / auditing skills
+
+- List all skills: `ls .agents/skills/`
+- Validate a skill: check that `SKILL.md` exists, frontmatter has `name` and `description`, `name` matches the directory
+- For full format rules, see `references/skill-format.md`
+
+## Progressive Disclosure
+
+| Level | Content | When to load |
+|-------|---------|--------------|
+| 1 | `name` + `description` | Always |
+| 2 | `SKILL.md` body (this file) | When skill is triggered |
+| 3 | `references/` files | When you need format details or examples |
+
+Read `references/skill-format.md` for complete frontmatter rules, naming constraints, and a full worked example.

--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -21,20 +21,23 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 3. Create `SKILL.md` — required frontmatter fields: `name` (must match directory), `description` (what it does and when to use it)
 4. Write a clear Markdown body with instructions agents can follow directly
 5. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
-6. Commit: `add <skill-name> skill: <one-line summary>`
+6. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
+7. Commit: `add <skill-name> skill: <one-line summary>`
 
 ### Updating a skill
 
 1. Read the existing `SKILL.md` before making changes
 2. Keep the `name` field in sync with the directory name — never rename one without the other
 3. Update `metadata.version` when the instructions change meaningfully
-4. Commit: `update <skill-name> skill: <one-line summary of change>`
+4. Review `AGENTS.md` — update if the changes affect anything documented there
+5. Commit: `update <skill-name> skill: <one-line summary of change>`
 
 ### Deleting a skill
 
 1. Confirm with the user before deleting
 2. Remove the entire `.agents/skills/<skill-name>/` directory
-3. Commit: `remove <skill-name> skill: <reason>`
+3. Review `AGENTS.md` — remove any references to the deleted skill
+4. Commit: `remove <skill-name> skill: <reason>`
 
 ### Reviewing / auditing skills
 

--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: skills
 description: >
-  Creates, updates, and manages reusable agent skills in this repository.
-  Use when the user asks to add a new skill, modify an existing skill,
-  delete a skill, or review the skill structure and conventions.
+  Creates, updates, and manages reusable agent skills.
 license: Apache-2.0
 metadata:
   author: geemus

--- a/.agents/skills/skills/references/skill-format.md
+++ b/.agents/skills/skills/references/skill-format.md
@@ -1,0 +1,125 @@
+# Skill Format Reference
+
+Full specification for the Agent Skills format used in this repository.
+Canonical spec: https://agentskills.io/specification
+
+## Directory Layout
+
+```
+.agents/skills/<skill-name>/
+├── SKILL.md        # Required: YAML frontmatter + Markdown instructions
+├── scripts/        # Optional: executable scripts (Python, Bash, JS, etc.)
+├── references/     # Optional: reference material, API docs, schemas
+└── assets/         # Optional: templates, examples, other static resources
+```
+
+## SKILL.md Frontmatter
+
+```yaml
+---
+name: skill-name          # required
+description: >            # required
+  What the skill does and when to invoke it. Injected into agent system
+  prompt — write in third person, max 1024 characters.
+license: Apache-2.0       # optional
+metadata:                 # optional
+  author: your-handle
+  version: "1.0"
+allowed-tools:            # optional: restrict tool access within the skill
+  - Bash
+  - Read
+---
+```
+
+### `name` rules
+
+- Lowercase letters (`a–z`), digits (`0–9`), and hyphens (`-`) only
+- 1–64 characters
+- No leading, trailing, or consecutive hyphens
+- Must match the parent directory name exactly
+
+### `description` rules
+
+- Non-empty; maximum 1024 characters
+- Written in third person (agents read this for discovery)
+- Must describe both *what* the skill does and *when* to invoke it
+
+## Markdown Body
+
+Recommended structure:
+
+```markdown
+# Skill Name
+
+Brief purpose statement.
+
+## Instructions
+
+Step-by-step guidance for the agent.
+
+## Examples
+
+Concrete inputs and expected outputs.
+```
+
+Write instructions agents can follow without needing to infer intent.
+Prefer explicit over implicit.
+
+## Progressive Disclosure Levels
+
+| Level | Content | When loaded | Target size |
+|-------|---------|-------------|-------------|
+| 1 | `name` + `description` frontmatter | Always (startup) | ~100 tokens |
+| 2 | `SKILL.md` body | When skill is triggered | < 5,000 tokens |
+| 3 | `scripts/`, `references/`, `assets/` | On demand, via Bash | Unlimited |
+
+Keep `SKILL.md` lean. Move large examples, schemas, and reference docs into `references/` or `assets/` and instruct agents to read them on demand.
+
+## Worked Example
+
+Directory: `.agents/skills/pdf/`
+
+```
+pdf/
+├── SKILL.md
+└── references/
+    └── pdfminer-api.md
+```
+
+`SKILL.md`:
+
+```markdown
+---
+name: pdf
+description: >
+  Extracts and summarizes content from PDF files. Use when the user
+  asks to read, parse, or extract text from a PDF document.
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# PDF
+
+Extracts text and metadata from PDF files using pdfminer.
+
+## Instructions
+
+1. Check that `pdfminer.six` is installed: `pip show pdfminer.six`
+2. Run `scripts/extract.py <path>` to extract text
+3. Summarize the extracted content for the user
+
+For full API details, read `references/pdfminer-api.md`.
+```
+
+## Conventions
+
+- One skill per directory — do not bundle unrelated tasks
+- Scripts must be self-contained or document their dependencies clearly
+- Never commit secrets, tokens, or credentials inside a skill
+- Skills that call external services must document required environment variables in `SKILL.md`
+- Skills performing destructive operations must include an explicit confirmation step

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,71 +28,13 @@ Skills live under `.agents/skills/` so that agents running within this repositor
 
 ## Skills Format
 
-Each skill is a **directory** named after the skill. The directory must contain a `SKILL.md` file with YAML frontmatter followed by Markdown instructions. See the [Agent Skills specification](https://agentskills.io/specification) for full details.
+Each skill is a **directory** named after the skill containing a `SKILL.md` file with YAML frontmatter and Markdown instructions.
 
-### Frontmatter
+For full format rules, naming constraints, progressive disclosure levels, and a worked example, use the **`skills`** skill or read `.agents/skills/skills/references/skill-format.md` directly.
 
-```yaml
----
-name: skill-name          # required: must match the directory name
-description: >            # required: what this skill does and when to use it
-  Extracts and summarizes content from PDF files. Use when the user
-  asks to read, parse, or extract text from a PDF document.
-license: Apache-2.0       # optional
-metadata:                 # optional: version tracking, authorship
-  author: your-handle
-  version: "1.0"
-allowed-tools:            # optional: restrict which tools the skill may use
-  - Bash
-  - Read
----
-```
+## Adding or Managing Skills
 
-**`name`** rules:
-- Lowercase letters, numbers, and hyphens only
-- 1–64 characters; no leading/trailing/consecutive hyphens
-- Must match the parent directory name exactly
-
-**`description`** rules:
-- Non-empty, maximum 1024 characters
-- Write in third person — this text is injected into the system prompt for discovery
-- Include both *what* the skill does and *when* to invoke it
-
-### Markdown body
-
-Write whatever helps agents perform the task effectively. Recommended sections:
-
-```markdown
-# Skill Name
-
-Brief overview of the skill's purpose.
-
-## Instructions
-
-Step-by-step guidance for the agent to follow.
-
-## Examples
-
-Concrete examples with inputs and expected outputs.
-```
-
-### Progressive disclosure
-
-Skills load in three stages — keep each lean:
-
-| Level | Content | When loaded | Target size |
-|-------|---------|-------------|-------------|
-| 1 | `name` + `description` frontmatter | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body | When skill is triggered | < 5,000 tokens |
-| 3 | `scripts/`, `references/`, `assets/` | On demand, via bash | Unlimited |
-
-## Adding a New Skill
-
-1. Create a directory: `.agents/skills/<skill-name>/` (lowercase, hyphen-separated)
-2. Add `.agents/skills/<skill-name>/SKILL.md` with `name:` and `description:` frontmatter
-3. Write clear, concrete instructions in the Markdown body
-4. Add `scripts/`, `references/`, or `assets/` as needed for Level 3 content
-5. Commit: `add <skill-name> skill: <one-line summary>`
+Use the **`skills`** skill — it covers creating, updating, and deleting skills with the correct conventions and commit messages.
 
 ## Git Workflow
 


### PR DESCRIPTION
moves full format spec and worked example into references/skill-format.md
deduplicates AGENTS.md to a short pointer to the skill