### PR TITLE
add plan skill: generate detailed work plan and write to GitHub issue

### DIFF
--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,7 +8,15 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.0"
+  version: "2.1"
+allowed-tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+  - mcp__github__list_issues
+  - mcp__github__list_pull_requests
+  - mcp__github__issue_write
 ---
 
 # Plan
@@ -24,7 +32,7 @@ Collect the following (ask only for what is missing):
 - **Work description** — what needs to be done (required; may be provided inline as skill args)
 - **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result; only ask if the remote cannot be determined
 - **Issue title** — generate one from the description if not provided
-- **Labels** — if not provided, suggest defaults based on the label strategy in step 3; confirm with the user before applying
+- **Labels** — if not provided, suggest defaults based on the label strategy in step 6; confirm with the user before applying
 
 ### 2. Survey the context
 
@@ -56,7 +64,7 @@ The chosen approach and why it was selected over alternatives. One short paragra
 Explicit statements the plan depends on being true (e.g. "The existing auth middleware can be reused", "No breaking API changes are needed"). Flag anything that, if wrong, would require replanning.
 
 #### Tasks
-Ordered, actionable tasks as GitHub Markdown checkboxes. For non-trivial work, group into phases. Each task should be independently completable.
+Ordered, actionable tasks as GitHub Markdown checkboxes. For non-trivial work, group into phases. Each task should have a single, clear deliverable.
 
 Annotate dependencies explicitly:
 
@@ -71,18 +79,12 @@ Annotate dependencies explicitly:
 Mark tasks that can run in parallel with a note: _(parallel with: Task X)_.
 
 #### Acceptance Criteria
-A bulleted list of pass/fail conditions. Each criterion must be verifiable. Pair criteria with the exact command or method to verify them where possible:
+A bulleted list of pass/fail conditions. Each criterion must be verifiable. Pair each with the exact command or action used to verify it:
 
 ```
 - All existing tests pass: `npm test`
 - Rate limit headers present on API responses: `curl -I /api/... | grep X-RateLimit`
 ```
-
-#### Verification Steps
-A short ordered checklist of commands or actions to run at the end to confirm the work is complete. This is the "definition of done" in executable form.
-
-#### Assumptions
-*See above — include in the plan body.*
 
 #### Open Questions
 Unknowns that need resolution before or during the work. Distinct from Assumptions: these are things the plan genuinely cannot answer yet. Omit this section if there are none.
@@ -101,7 +103,7 @@ Fix any issues found, then proceed.
 
 ### 6. Create the GitHub issue
 
-Use `mcp__github__create_issue` with:
+Use `mcp__github__issue_write` with:
 - `owner` and `repo` from step 1
 - `title` from step 1
 - `body` as the full Markdown plan from step 4
@@ -139,7 +141,7 @@ Claude will ask for the work description. Repository is inferred from `git remot
 ...
 
 ## Approach
-...
+We will use approach X because it minimizes Y; the key tradeoff is Z.
 
 ## Assumptions
 - ...
@@ -160,10 +162,6 @@ Claude will ask for the work description. Repository is inferred from `git remot
 ## Acceptance Criteria
 - All tests pass: `npm test`
 - ...
-
-## Verification Steps
-1. `npm test`
-2. ...
 
 ## Open Questions
 - ...

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,7 +8,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.4"
+  version: "1.0"
 allowed-tools:
   - Bash
   - Glob
@@ -18,6 +18,7 @@ allowed-tools:
   - mcp__github__list_issues
   - mcp__github__list_pull_requests
   - mcp__github__issue_write
+  - mcp__github__create_issue
 ---
 
 # Plan
@@ -31,7 +32,8 @@ Turns a description of work into a structured, executable plan written to a GitH
 Collect the following (ask only for what is missing):
 
 - **Work description** — what needs to be done (required; may be provided inline as skill args). If the description is too vague to decompose into concrete tasks without guessing, ask 1–2 targeted clarifying questions before continuing.
-- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result; only ask if the remote cannot be determined.
+- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result. Parse both HTTPS (`https://github.com/owner/repo.git`) and SSH (`git@github.com:owner/repo.git`) remote formats — for SSH remotes, split on `:` then strip `.git`. Only ask if the remote cannot be determined.
+- **Sub-issues** — if the work description clearly involves multiple distinct phases or bodies of work, ask now whether the user wants each phase tracked as a separate sub-issue linked to a parent.
 
 Check `gh` availability once here and carry the result forward — do not re-check in later steps:
 ```
@@ -44,16 +46,17 @@ Labels will be suggested after the plan is generated in step 4. Do not ask for t
 
 Before planning, ground the plan in reality:
 
-- **Codebase scan**: Use `Glob` to map the directory structure around the relevant area. Use `Grep` to search for key terms from the work description. Read `AGENTS.md`, `CLAUDE.md`, and `README.md` if present for conventions and constraints.
-- **Open issues / PRs**: Check for related work using whichever path was determined in step 1:
-  - `gh` available: `gh issue list --repo <owner/repo> --state open --search "<keyword from work description>"` and `gh pr list --repo <owner/repo> --state open --search "<keyword>"`
+- **Codebase scan**: Use `Glob` to map the directory structure around the relevant area. Use `Grep` to search for key terms from the work description. Read `AGENTS.md`, `CLAUDE.md`, and `README.md` if present for conventions and constraints. If none of these files exist, note the absence and continue.
+- **Open issues / PRs**: Check for related work using whichever path was determined in step 1. Choose a specific keyword from the work description (a noun or action that would appear in issue titles) and use it consistently:
+  - `gh` available: `gh issue list --repo <owner/repo> --state open --search "<keyword>"` and `gh pr list --repo <owner/repo> --state open --search "<keyword>"`
   - `gh` unavailable: `mcp__github__list_issues` / `mcp__github__list_pull_requests`
+  - If no issues or PRs exist yet, note the absence and continue.
 - **Constraints**: Note tech stack, dependencies, CI requirements, and anything that restricts the approach.
 - Record what already exists and what must be built from scratch — this feeds the Background section.
 
 ### 3. Consider approaches
 
-Briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section.
+For non-trivial design decisions, briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section. For straightforward tasks where there is only one sensible implementation path, skip this step.
 
 ### 4. Generate the plan
 
@@ -97,13 +100,9 @@ A bulleted list of pass/fail conditions. Each criterion must be verifiable. Pair
 #### Open Questions
 Unknowns that need resolution before or during the work. Distinct from Assumptions: these are things the plan genuinely cannot answer yet. Omit this section if there are none.
 
-After drafting the plan, suggest labels for the user to confirm before proceeding to step 5:
-- *Type* (pick one): `feature`, `bug`, `refactor`, `docs`, `test`
-- *Priority* (pick one): `priority: high`, `priority: medium`, `priority: low`
+### 5. Self-review before presenting
 
-### 5. Self-review before posting
-
-Evaluate the draft plan against these checks. Fix any issues found before continuing.
+Evaluate the draft plan against these checks. Fix any issues found silently before presenting to the user.
 
 - Does every task have a clear, actionable description? (If not, rewrite vague tasks.)
 - Are dependencies complete and correct?
@@ -112,21 +111,32 @@ Evaluate the draft plan against these checks. Fix any issues found before contin
 - Is the plan appropriately scoped — neither too coarse nor too granular?
 - Is the Approach section present and does it name the chosen approach, the reason it was selected, and its key tradeoff?
 
-### 6. Create the GitHub issue
+### 6. Present the plan and confirm labels
+
+Present the finished plan to the user, then suggest labels for confirmation:
+- *Type* (pick one): `feature`, `bug`, `refactor`, `docs`, `test`
+- *Priority* (pick one): `priority: high`, `priority: medium`, `priority: low`
+
+Wait for the user to confirm the labels (or propose different ones) before proceeding. Note: if the selected labels do not yet exist in the repository, `gh issue create` will fail — create them first with `gh label create` or use only labels that already exist.
+
+### 7. Create the GitHub issue
+
+Derive the issue title from the Objective: use a concise phrase (under 72 characters) that captures the core action and subject (e.g. "Add rate limiting to the public API").
 
 Use the path determined in step 1:
 
-- **`gh` available:** Write the plan body to a uniquely named temp file using the `Write` tool (avoids shell quoting issues and concurrent collisions), then create the issue:
+- **`gh` available:** Write the plan body to a uniquely named temp file using the `Write` tool (avoids shell quoting issues and concurrent collisions), then create the issue and clean up the temp file:
   ```
-  gh issue create --repo <owner/repo> --title "<title>" --body-file /tmp/plan-body-<epoch>.md --label "feature" --label "priority: high"
+  gh issue create --repo <owner/repo> --title "<derived title>" --body-file /tmp/plan-body-<epoch>.md --label "<type-label>" --label "<priority-label>"
+  rm /tmp/plan-body-<epoch>.md
   ```
-  Use a separate `--label` flag for each label. Replace `<epoch>` with the current Unix timestamp.
+  Use a separate `--label` flag for each label confirmed in step 6. Replace `<epoch>` with the current Unix timestamp.
 
-- **`gh` unavailable:** Use `mcp__github__issue_write` with `method: "create"`, `owner`, `repo`, `title`, `body`, and `labels`.
+- **`gh` unavailable:** Use `mcp__github__issue_write` with `method: "create"`, `owner`, `repo`, `title`, `body`, and `labels` (using only the labels confirmed in step 6).
 
-**Sub-issues**: If the plan has more than ~7 tasks or multiple distinct phases, suggest to the user that each phase (or major task group) be tracked as a separate sub-issue linked to this parent. Offer to create them.
+**Sub-issues**: If sub-issue tracking was agreed in step 1, create a sub-issue for each phase now and link them to the parent issue.
 
-### 7. Report back
+### 8. Report back
 
 Share the issue URL, state the number of tasks and phases, and call out any open questions or high-risk assumptions that should be resolved early.
 
@@ -154,9 +164,6 @@ Claude will ask for the work description. Repository is inferred from `git remot
 ## Approach
 We will use approach X because it minimizes Y; the key tradeoff is Z.
 
-## Assumptions
-- ...
-
 ## Tasks
 
 ### Phase 1 — Research
@@ -172,8 +179,5 @@ We will use approach X because it minimizes Y; the key tradeoff is Z.
 
 ## Acceptance Criteria
 - All tests pass: `npm test`
-- ...
-
-## Open Questions
 - ...
 ```

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,7 +8,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.1"
+  version: "2.2"
 allowed-tools:
   - Bash
   - Glob
@@ -39,7 +39,9 @@ Collect the following (ask only for what is missing):
 Before planning, ground the plan in reality:
 
 - Scan the codebase for existing patterns, conventions, and related code relevant to the work
-- Check for open issues or PRs related to the same area (`mcp__github__list_issues`, `mcp__github__list_pull_requests`)
+- Check for open issues or PRs related to the same area:
+  - Preferred: `gh issue list --state open` / `gh pr list --state open`
+  - Fallback: `mcp__github__list_issues` / `mcp__github__list_pull_requests`
 - Note any constraints (tech stack, dependencies, CI requirements, etc.)
 - Record what already exists and what must be built from scratch — this becomes the Background section
 
@@ -103,11 +105,13 @@ Fix any issues found, then proceed.
 
 ### 6. Create the GitHub issue
 
-Use `mcp__github__issue_write` with:
-- `owner` and `repo` from step 1
-- `title` from step 1
-- `body` as the full Markdown plan from step 4
-- `labels` from step 1
+Create the issue using whichever is available:
+
+- **Preferred — `gh` CLI:**
+  ```
+  gh issue create --title "<title>" --body "<plan>" --label "<labels>"
+  ```
+- **Fallback — MCP:** use `mcp__github__issue_write` with `owner`, `repo`, `title`, `body`, and `labels`
 
 **Label strategy** — apply one label from each applicable category:
 - *Type*: `feature`, `bug`, `refactor`, `docs`, `test`

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,7 +8,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.2"
+  version: "2.3"
 allowed-tools:
   - Bash
   - Glob
@@ -40,7 +40,7 @@ Before planning, ground the plan in reality:
 
 - Scan the codebase for existing patterns, conventions, and related code relevant to the work
 - Check for open issues or PRs related to the same area:
-  - Preferred: `gh issue list --state open` / `gh pr list --state open`
+  - Preferred: `gh issue list --repo <owner/repo> --state open --search "<keyword from work description>"` / `gh pr list --repo <owner/repo> --state open --search "<keyword>"`
   - Fallback: `mcp__github__list_issues` / `mcp__github__list_pull_requests`
 - Note any constraints (tech stack, dependencies, CI requirements, etc.)
 - Record what already exists and what must be built from scratch — this becomes the Background section
@@ -100,17 +100,27 @@ Before creating the issue, evaluate the draft plan:
 - Does the acceptance criteria cover the full objective?
 - Are any assumptions likely to be wrong?
 - Is the plan appropriately scoped — neither too coarse nor too granular?
+- Is the Approach section present and does it name the chosen approach, the reason it was selected, and its key tradeoff?
 
 Fix any issues found, then proceed.
 
 ### 6. Create the GitHub issue
 
-Create the issue using whichever is available:
+First, check whether `gh` is available and authenticated:
+```
+gh auth status
+```
+If this succeeds, use `gh`. If it fails or `gh` is not found, use the MCP fallback.
 
-- **Preferred — `gh` CLI:**
+- **Preferred — `gh` CLI:** write the plan body to a temp file to avoid shell quoting issues, then create the issue:
   ```
-  gh issue create --title "<title>" --body "<plan>" --label "<labels>"
+  cat > /tmp/plan-body.md << 'EOF'
+  <full plan Markdown>
+  EOF
+  gh issue create --repo <owner/repo> --title "<title>" --body-file /tmp/plan-body.md --label "feature" --label "priority: high"
   ```
+  Use a separate `--label` flag for each label.
+
 - **Fallback — MCP:** use `mcp__github__issue_write` with `owner`, `repo`, `title`, `body`, and `labels`
 
 **Label strategy** — apply one label from each applicable category:

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,60 +8,114 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.1"
+  version: "2.0"
 ---
 
 # Plan
 
-Turns a description of work into a structured plan written to a GitHub issue.
+Turns a description of work into a structured, executable plan written to a GitHub issue.
 
 ## Instructions
 
 ### 1. Gather inputs
 
-Collect the following from the user (ask only for what is missing):
+Collect the following (ask only for what is missing):
 
 - **Work description** — what needs to be done (required; may be provided inline as skill args)
-- **GitHub repository** — infer `owner/repo` from the current git context by running `git remote get-url origin` and parsing the result; only ask the user if the remote cannot be determined
-- **Issue title** — short summary; generate one from the description if not provided
-- **Labels** — optional comma-separated list of labels to apply to the issue
+- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result; only ask if the remote cannot be determined
+- **Issue title** — generate one from the description if not provided
+- **Labels** — if not provided, suggest defaults based on the label strategy in step 3; confirm with the user before applying
 
-### 2. Generate the plan
+### 2. Survey the context
 
-Think through the work carefully and produce a plan with these sections:
+Before planning, ground the plan in reality:
+
+- Scan the codebase for existing patterns, conventions, and related code relevant to the work
+- Check for open issues or PRs related to the same area (`mcp__github__list_issues`, `mcp__github__list_pull_requests`)
+- Note any constraints (tech stack, dependencies, CI requirements, etc.)
+- Record what already exists and what must be built from scratch — this becomes the Background section
+
+### 3. Consider approaches
+
+Before committing to a plan, briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section in the issue.
+
+### 4. Generate the plan
+
+Produce a plan with these sections:
 
 #### Objective
 One or two sentences stating the goal and why it matters.
 
 #### Background
-Relevant context: what exists today, why the work is needed, any constraints.
+What exists today, what the context survey found, why this work is needed, and any constraints.
+
+#### Approach
+The chosen approach and why it was selected over alternatives. One short paragraph; include the key tradeoff.
+
+#### Assumptions
+Explicit statements the plan depends on being true (e.g. "The existing auth middleware can be reused", "No breaking API changes are needed"). Flag anything that, if wrong, would require replanning.
 
 #### Tasks
-A numbered, ordered list of concrete tasks. For non-trivial work, group tasks into phases (e.g. *Phase 1 — Research*, *Phase 2 — Implementation*, *Phase 3 — Validation*). Each task should be actionable and independently completable. Use sub-tasks (indented checkboxes) for steps within a task.
+Ordered, actionable tasks as GitHub Markdown checkboxes. For non-trivial work, group into phases. Each task should be independently completable.
 
-Format tasks as GitHub Markdown task lists:
+Annotate dependencies explicitly:
+
 ```
-- [ ] Task description
+- [ ] Task A — no dependencies
+- [ ] Task B — no dependencies
+- [ ] Task C _(depends on: Task A)_
   - [ ] Sub-task
+- [ ] Task D _(depends on: Task B, Task C)_
 ```
+
+Mark tasks that can run in parallel with a note: _(parallel with: Task X)_.
 
 #### Acceptance Criteria
-A bulleted list of conditions that must be true for the work to be considered complete. Write each criterion so it can be evaluated as pass/fail.
+A bulleted list of pass/fail conditions. Each criterion must be verifiable. Pair criteria with the exact command or method to verify them where possible:
+
+```
+- All existing tests pass: `npm test`
+- Rate limit headers present on API responses: `curl -I /api/... | grep X-RateLimit`
+```
+
+#### Verification Steps
+A short ordered checklist of commands or actions to run at the end to confirm the work is complete. This is the "definition of done" in executable form.
+
+#### Assumptions
+*See above — include in the plan body.*
 
 #### Open Questions
-Any unknowns, risks, or decisions that need resolution before or during the work. Leave this section empty (or omit it) if there are none.
+Unknowns that need resolution before or during the work. Distinct from Assumptions: these are things the plan genuinely cannot answer yet. Omit this section if there are none.
 
-### 3. Create the GitHub issue
+### 5. Self-review before posting
 
-Use the GitHub MCP tool `mcp__github__create_issue` with:
-- `owner` and `repo` from the repository input
+Before creating the issue, evaluate the draft plan:
+
+- Does every task have a clear, actionable description? (If not, rewrite vague tasks.)
+- Are dependencies complete and correct?
+- Does the acceptance criteria cover the full objective?
+- Are any assumptions likely to be wrong?
+- Is the plan appropriately scoped — neither too coarse nor too granular?
+
+Fix any issues found, then proceed.
+
+### 6. Create the GitHub issue
+
+Use `mcp__github__create_issue` with:
+- `owner` and `repo` from step 1
 - `title` from step 1
-- `body` as the full Markdown plan from step 2
-- `labels` if provided
+- `body` as the full Markdown plan from step 4
+- `labels` from step 1
 
-### 4. Report back
+**Label strategy** — apply one label from each applicable category:
+- *Type*: `feature`, `bug`, `refactor`, `docs`, `test`
+- *Priority*: `priority: high`, `priority: medium`, `priority: low`
 
-Share the created issue URL with the user and briefly summarize the plan structure (number of tasks, phases if any).
+**Sub-issues**: If the plan has more than ~7 tasks or multiple distinct phases, suggest to the user that each phase (or major task group) be tracked as a separate sub-issue linked to this parent. Offer to create them.
+
+### 7. Report back
+
+Share the issue URL, state the number of tasks and phases, and call out any open questions or high-risk assumptions that should be resolved early.
 
 ## Examples
 
@@ -74,7 +128,7 @@ Share the created issue URL with the user and briefly summarize the plan structu
 ```
 /plan
 ```
-Claude will ask for the work description. The repository is inferred automatically from `git remote get-url origin`.
+Claude will ask for the work description. Repository is inferred from `git remote get-url origin`.
 
 **Generated issue body structure:**
 ```markdown
@@ -84,16 +138,32 @@ Claude will ask for the work description. The repository is inferred automatical
 ## Background
 ...
 
+## Approach
+...
+
+## Assumptions
+- ...
+
 ## Tasks
 
 ### Phase 1 — Research
-- [ ] ...
+- [ ] Task A
+- [ ] Task B _(parallel with: Task A)_
 
 ### Phase 2 — Implementation
-- [ ] ...
+- [ ] Task C _(depends on: Task A)_
+  - [ ] Sub-task
+
+### Phase 3 — Validation
+- [ ] Task D _(depends on: Task C)_
 
 ## Acceptance Criteria
+- All tests pass: `npm test`
 - ...
+
+## Verification Steps
+1. `npm test`
+2. ...
 
 ## Open Questions
 - ...

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -8,12 +8,13 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.3"
+  version: "2.4"
 allowed-tools:
   - Bash
   - Glob
   - Grep
   - Read
+  - Write
   - mcp__github__list_issues
   - mcp__github__list_pull_requests
   - mcp__github__issue_write
@@ -29,25 +30,30 @@ Turns a description of work into a structured, executable plan written to a GitH
 
 Collect the following (ask only for what is missing):
 
-- **Work description** — what needs to be done (required; may be provided inline as skill args)
-- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result; only ask if the remote cannot be determined
-- **Issue title** — generate one from the description if not provided
-- **Labels** — if not provided, suggest defaults based on the label strategy in step 6; confirm with the user before applying
+- **Work description** — what needs to be done (required; may be provided inline as skill args). If the description is too vague to decompose into concrete tasks without guessing, ask 1–2 targeted clarifying questions before continuing.
+- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result; only ask if the remote cannot be determined.
+
+Check `gh` availability once here and carry the result forward — do not re-check in later steps:
+```
+gh auth status 2>/dev/null && echo "gh: available" || echo "gh: unavailable"
+```
+
+Labels will be suggested after the plan is generated in step 4. Do not ask for them now.
 
 ### 2. Survey the context
 
 Before planning, ground the plan in reality:
 
-- Scan the codebase for existing patterns, conventions, and related code relevant to the work
-- Check for open issues or PRs related to the same area:
-  - Preferred: `gh issue list --repo <owner/repo> --state open --search "<keyword from work description>"` / `gh pr list --repo <owner/repo> --state open --search "<keyword>"`
-  - Fallback: `mcp__github__list_issues` / `mcp__github__list_pull_requests`
-- Note any constraints (tech stack, dependencies, CI requirements, etc.)
-- Record what already exists and what must be built from scratch — this becomes the Background section
+- **Codebase scan**: Use `Glob` to map the directory structure around the relevant area. Use `Grep` to search for key terms from the work description. Read `AGENTS.md`, `CLAUDE.md`, and `README.md` if present for conventions and constraints.
+- **Open issues / PRs**: Check for related work using whichever path was determined in step 1:
+  - `gh` available: `gh issue list --repo <owner/repo> --state open --search "<keyword from work description>"` and `gh pr list --repo <owner/repo> --state open --search "<keyword>"`
+  - `gh` unavailable: `mcp__github__list_issues` / `mcp__github__list_pull_requests`
+- **Constraints**: Note tech stack, dependencies, CI requirements, and anything that restricts the approach.
+- Record what already exists and what must be built from scratch — this feeds the Background section.
 
 ### 3. Consider approaches
 
-Before committing to a plan, briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section in the issue.
+Briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section.
 
 ### 4. Generate the plan
 
@@ -63,7 +69,7 @@ What exists today, what the context survey found, why this work is needed, and a
 The chosen approach and why it was selected over alternatives. One short paragraph; include the key tradeoff.
 
 #### Assumptions
-Explicit statements the plan depends on being true (e.g. "The existing auth middleware can be reused", "No breaking API changes are needed"). Flag anything that, if wrong, would require replanning.
+Explicit statements the plan depends on being true (e.g. "The existing auth middleware can be reused", "No breaking API changes are needed"). Flag anything that, if wrong, would require replanning. Omit this section if there are none.
 
 #### Tasks
 Ordered, actionable tasks as GitHub Markdown checkboxes. For non-trivial work, group into phases. Each task should have a single, clear deliverable.
@@ -91,9 +97,13 @@ A bulleted list of pass/fail conditions. Each criterion must be verifiable. Pair
 #### Open Questions
 Unknowns that need resolution before or during the work. Distinct from Assumptions: these are things the plan genuinely cannot answer yet. Omit this section if there are none.
 
+After drafting the plan, suggest labels for the user to confirm before proceeding to step 5:
+- *Type* (pick one): `feature`, `bug`, `refactor`, `docs`, `test`
+- *Priority* (pick one): `priority: high`, `priority: medium`, `priority: low`
+
 ### 5. Self-review before posting
 
-Before creating the issue, evaluate the draft plan:
+Evaluate the draft plan against these checks. Fix any issues found before continuing.
 
 - Does every task have a clear, actionable description? (If not, rewrite vague tasks.)
 - Are dependencies complete and correct?
@@ -102,30 +112,17 @@ Before creating the issue, evaluate the draft plan:
 - Is the plan appropriately scoped — neither too coarse nor too granular?
 - Is the Approach section present and does it name the chosen approach, the reason it was selected, and its key tradeoff?
 
-Fix any issues found, then proceed.
-
 ### 6. Create the GitHub issue
 
-First, check whether `gh` is available and authenticated:
-```
-gh auth status
-```
-If this succeeds, use `gh`. If it fails or `gh` is not found, use the MCP fallback.
+Use the path determined in step 1:
 
-- **Preferred — `gh` CLI:** write the plan body to a temp file to avoid shell quoting issues, then create the issue:
+- **`gh` available:** Write the plan body to a uniquely named temp file using the `Write` tool (avoids shell quoting issues and concurrent collisions), then create the issue:
   ```
-  cat > /tmp/plan-body.md << 'EOF'
-  <full plan Markdown>
-  EOF
-  gh issue create --repo <owner/repo> --title "<title>" --body-file /tmp/plan-body.md --label "feature" --label "priority: high"
+  gh issue create --repo <owner/repo> --title "<title>" --body-file /tmp/plan-body-<epoch>.md --label "feature" --label "priority: high"
   ```
-  Use a separate `--label` flag for each label.
+  Use a separate `--label` flag for each label. Replace `<epoch>` with the current Unix timestamp.
 
-- **Fallback — MCP:** use `mcp__github__issue_write` with `owner`, `repo`, `title`, `body`, and `labels`
-
-**Label strategy** — apply one label from each applicable category:
-- *Type*: `feature`, `bug`, `refactor`, `docs`, `test`
-- *Priority*: `priority: high`, `priority: medium`, `priority: low`
+- **`gh` unavailable:** Use `mcp__github__issue_write` with `method: "create"`, `owner`, `repo`, `title`, `body`, and `labels`.
 
 **Sub-issues**: If the plan has more than ~7 tasks or multiple distinct phases, suggest to the user that each phase (or major task group) be tracked as a separate sub-issue linked to this parent. Offer to create them.
 

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: work-plan
+name: plan
 description: >
   Generates a detailed, structured work plan from a description of work to be
   done, then creates a GitHub issue containing the plan. Invoke when the user
@@ -11,7 +11,7 @@ metadata:
   version: "1.1"
 ---
 
-# Work Plan
+# Plan
 
 Turns a description of work into a structured plan written to a GitHub issue.
 
@@ -67,12 +67,12 @@ Share the created issue URL with the user and briefly summarize the plan structu
 
 **Invocation (inline description):**
 ```
-/work-plan Add rate limiting to the public API
+/plan Add rate limiting to the public API
 ```
 
 **Invocation (interactive):**
 ```
-/work-plan
+/plan
 ```
 Claude will ask for the work description. The repository is inferred automatically from `git remote get-url origin`.
 

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -2,9 +2,11 @@
 name: plan
 description: >
   Generates a detailed, structured work plan from a description of work to be
-  done, then creates a GitHub issue containing the plan. Invoke when the user
-  wants to plan out a feature, bug fix, project, or any body of work and
-  capture it as a GitHub issue for tracking and collaboration.
+  done, then creates a GitHub issue containing the plan. Interactive: asks
+  clarifying questions when needed, presents the plan for review, and confirms
+  labels before creating the issue. Invoke when the user wants to plan out a
+  feature, bug fix, project, or any body of work and capture it as a GitHub
+  issue for tracking and collaboration.
 license: Apache-2.0
 metadata:
   author: geemus
@@ -17,7 +19,6 @@ allowed-tools:
   - Write
   - mcp__github__list_issues
   - mcp__github__list_pull_requests
-  - mcp__github__issue_write
   - mcp__github__create_issue
 ---
 
@@ -32,7 +33,7 @@ Turns a description of work into a structured, executable plan written to a GitH
 Collect the following (ask only for what is missing):
 
 - **Work description** — what needs to be done (required; may be provided inline as skill args). If the description is too vague to decompose into concrete tasks without guessing, ask 1–2 targeted clarifying questions before continuing.
-- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result. Parse both HTTPS (`https://github.com/owner/repo.git`) and SSH (`git@github.com:owner/repo.git`) remote formats — for SSH remotes, split on `:` then strip `.git`. Only ask if the remote cannot be determined.
+- **GitHub repository** — infer `owner/repo` by running `git remote get-url origin` and parsing the result. Parse both HTTPS (`https://github.com/owner/repo.git`) and SSH (`git@github.com:owner/repo.git`) remote formats — for SSH remotes, split on `:` then strip `.git`. If the command exits non-zero, produces empty output, or the result cannot be parsed into `owner/repo`, ask the user for the repository explicitly.
 - **Sub-issues** — if the work description clearly involves multiple distinct phases or bodies of work, ask now whether the user wants each phase tracked as a separate sub-issue linked to a parent.
 
 Check `gh` availability once here and carry the result forward — do not re-check in later steps:
@@ -56,7 +57,7 @@ Before planning, ground the plan in reality:
 
 ### 3. Consider approaches
 
-For non-trivial design decisions, briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section. For straightforward tasks where there is only one sensible implementation path, skip this step.
+For non-trivial design decisions, briefly evaluate 2–3 alternative approaches. For each, note the key tradeoff. Select the best approach and document the rationale. This becomes the Approach section. Skip this step only when the work involves fewer than 3 tasks and there is clearly no meaningful choice between approaches.
 
 ### 4. Generate the plan
 
@@ -117,7 +118,11 @@ Present the finished plan to the user, then suggest labels for confirmation:
 - *Type* (pick one): `feature`, `bug`, `refactor`, `docs`, `test`
 - *Priority* (pick one): `priority: high`, `priority: medium`, `priority: low`
 
-Wait for the user to confirm the labels (or propose different ones) before proceeding. Note: if the selected labels do not yet exist in the repository, `gh issue create` will fail — create them first with `gh label create` or use only labels that already exist.
+Wait for the user to confirm the labels (or propose different ones) before proceeding.
+
+Before creating the issue, verify the confirmed labels exist in the repository:
+- **`gh` available:** `gh label list --repo <owner/repo> --json name --jq '.[].name'` — compare against confirmed labels; create any missing ones with `gh label create <name> --repo <owner/repo>` before proceeding.
+- **`gh` unavailable:** skip the check and use only the labels the user confirmed; note in the report if any labels may not exist.
 
 ### 7. Create the GitHub issue
 
@@ -127,14 +132,15 @@ Use the path determined in step 1:
 
 - **`gh` available:** Write the plan body to a uniquely named temp file using the `Write` tool (avoids shell quoting issues and concurrent collisions), then create the issue and clean up the temp file:
   ```
-  gh issue create --repo <owner/repo> --title "<derived title>" --body-file /tmp/plan-body-<epoch>.md --label "<type-label>" --label "<priority-label>"
-  rm /tmp/plan-body-<epoch>.md
+  EPOCH=$(date +%s)
+  gh issue create --repo <owner/repo> --title "<derived title>" --body-file /tmp/plan-body-${EPOCH}.md --label "<type-label>" --label "<priority-label>"
+  rm /tmp/plan-body-${EPOCH}.md
   ```
-  Use a separate `--label` flag for each label confirmed in step 6. Replace `<epoch>` with the current Unix timestamp.
+  Use a separate `--label` flag for each label confirmed in step 6.
 
-- **`gh` unavailable:** Use `mcp__github__issue_write` with `method: "create"`, `owner`, `repo`, `title`, `body`, and `labels` (using only the labels confirmed in step 6).
+- **`gh` unavailable:** Use `mcp__github__create_issue` with `owner`, `repo`, `title`, `body`, and `labels` (using only the labels confirmed in step 6).
 
-**Sub-issues**: If sub-issue tracking was agreed in step 1, create a sub-issue for each phase now and link them to the parent issue.
+**Sub-issues**: If sub-issue tracking was agreed in step 1, create a child issue for each phase using the same method above. Link each child to the parent by adding a line to the parent issue body: `- Sub-issue: #<number> — <phase name>`. If `mcp__github__sub_issue_write` is available, use it to create the formal parent–child relationship.
 
 ### 8. Report back
 

--- a/.agents/skills/work-plan/SKILL.md
+++ b/.agents/skills/work-plan/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: work-plan
+description: >
+  Generates a detailed, structured work plan from a description of work to be
+  done, then creates a GitHub issue containing the plan. Invoke when the user
+  wants to plan out a feature, bug fix, project, or any body of work and
+  capture it as a GitHub issue for tracking and collaboration.
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Work Plan
+
+Turns a description of work into a structured plan written to a GitHub issue.
+
+## Instructions
+
+### 1. Gather inputs
+
+Collect the following from the user (ask only for what is missing):
+
+- **Work description** — what needs to be done (required; may be provided inline as skill args)
+- **GitHub repository** — `owner/repo` where the issue will be created (required)
+- **Issue title** — short summary; generate one from the description if not provided
+- **Labels** — optional comma-separated list of labels to apply to the issue
+
+### 2. Generate the plan
+
+Think through the work carefully and produce a plan with these sections:
+
+#### Objective
+One or two sentences stating the goal and why it matters.
+
+#### Background
+Relevant context: what exists today, why the work is needed, any constraints.
+
+#### Tasks
+A numbered, ordered list of concrete tasks. For non-trivial work, group tasks into phases (e.g. *Phase 1 — Research*, *Phase 2 — Implementation*, *Phase 3 — Validation*). Each task should be actionable and independently completable. Use sub-tasks (indented checkboxes) for steps within a task.
+
+Format tasks as GitHub Markdown task lists:
+```
+- [ ] Task description
+  - [ ] Sub-task
+```
+
+#### Acceptance Criteria
+A bulleted list of conditions that must be true for the work to be considered complete. Write each criterion so it can be evaluated as pass/fail.
+
+#### Open Questions
+Any unknowns, risks, or decisions that need resolution before or during the work. Leave this section empty (or omit it) if there are none.
+
+### 3. Create the GitHub issue
+
+Use the GitHub MCP tool `mcp__github__create_issue` with:
+- `owner` and `repo` from the repository input
+- `title` from step 1
+- `body` as the full Markdown plan from step 2
+- `labels` if provided
+
+### 4. Report back
+
+Share the created issue URL with the user and briefly summarize the plan structure (number of tasks, phases if any).
+
+## Examples
+
+**Invocation (inline description):**
+```
+/work-plan Add rate limiting to the public API — repo: acme/backend
+```
+
+**Invocation (interactive):**
+```
+/work-plan
+```
+Claude will ask for the work description and repository.
+
+**Generated issue body structure:**
+```markdown
+## Objective
+...
+
+## Background
+...
+
+## Tasks
+
+### Phase 1 — Research
+- [ ] ...
+
+### Phase 2 — Implementation
+- [ ] ...
+
+## Acceptance Criteria
+- ...
+
+## Open Questions
+- ...
+```

--- a/.agents/skills/work-plan/SKILL.md
+++ b/.agents/skills/work-plan/SKILL.md
@@ -8,7 +8,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Work Plan
@@ -22,7 +22,7 @@ Turns a description of work into a structured plan written to a GitHub issue.
 Collect the following from the user (ask only for what is missing):
 
 - **Work description** — what needs to be done (required; may be provided inline as skill args)
-- **GitHub repository** — `owner/repo` where the issue will be created (required)
+- **GitHub repository** — infer `owner/repo` from the current git context by running `git remote get-url origin` and parsing the result; only ask the user if the remote cannot be determined
 - **Issue title** — short summary; generate one from the description if not provided
 - **Labels** — optional comma-separated list of labels to apply to the issue
 
@@ -67,14 +67,14 @@ Share the created issue URL with the user and briefly summarize the plan structu
 
 **Invocation (inline description):**
 ```
-/work-plan Add rate limiting to the public API — repo: acme/backend
+/work-plan Add rate limiting to the public API
 ```
 
 **Invocation (interactive):**
 ```
 /work-plan
 ```
-Claude will ask for the work description and repository.
+Claude will ask for the work description. The repository is inferred automatically from `git remote get-url origin`.
 
 **Generated issue body structure:**
 ```markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,13 @@ Each skill is a **directory** named after the skill containing a `SKILL.md` file
 
 For full format rules, naming constraints, progressive disclosure levels, and a worked example, use the **`skills`** skill or read `.agents/skills/skills/references/skill-format.md` directly.
 
+## Available Skills
+
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| `skills` | `/skills` | Create, update, and manage skills in this repository |
+| `plan` | `/plan` | Generate a structured work plan and write it to a GitHub issue |
+
 ## Adding or Managing Skills
 
 Use the **`skills`** skill — it covers creating, updating, and deleting skills with the correct conventions and commit messages.


### PR DESCRIPTION
## Summary

- Adds a new `/plan` invocable skill that turns a description of work into a structured plan written to a GitHub issue
- Infers `owner/repo` from `git remote get-url origin` automatically; handles parse failures explicitly
- Incorporates agentic planning best practices based on research (ReAct, Reflexion, Plan-and-Execute, Tree-of-Thought)

## What the skill does

1. **Gathers inputs** — collects the work description; asks clarifying questions if too vague; checks `gh` availability once and carries the result forward; infers `owner/repo` from git remote (asks if command fails or output can't be parsed)
2. **Surveys context** — scans the codebase with `Glob`/`Grep`, checks `AGENTS.md`/`CLAUDE.md`/`README.md` for conventions, and searches open issues/PRs for related work
3. **Considers approaches** — evaluates 2–3 alternatives and documents the rationale; skips only when fewer than 3 tasks and no meaningful choice exists
4. **Generates a structured plan** with: Objective, Background, Approach, Assumptions, Tasks (with explicit dependency and parallelism annotations), Acceptance Criteria (with verification commands), and Open Questions
5. **Suggests labels** after the plan is generated (type + priority), confirmed by user before posting; verifies label existence before creating the issue and creates missing labels with `gh label create`
6. **Self-reviews** the draft before posting — checks tasks, dependencies, acceptance criteria, assumptions, scope, and Approach completeness
7. **Creates the GitHub issue** — prefers `gh issue create --body-file` with a uniquely named temp file (`EPOCH=$(date +%s)`); falls back to `mcp__github__create_issue`
8. **Reports back** with the issue URL, task/phase count, and any high-risk items to resolve early

Also updates `AGENTS.md` to add an Available Skills table listing `plan` and `skills`.

## Test plan

- [ ] Invoke `/plan` with an inline description and verify the issue is created with all sections present
- [ ] Invoke `/plan` with a vague description and verify clarifying questions are asked
- [ ] Verify `owner/repo` is inferred correctly from git remote without prompting
- [ ] Verify error path: if `git remote get-url origin` fails or is unparseable, user is asked for repo
- [ ] Verify `gh auth status` is checked once in step 1 and the result used in steps 2 and 7
- [ ] Verify tasks include dependency and parallelism annotations where appropriate
- [ ] Verify acceptance criteria include verification commands
- [ ] Verify label existence is checked and missing labels are created before `gh issue create`
- [ ] Verify label suggestions appear after plan generation and require confirmation
- [ ] Verify the temp file uses `EPOCH=$(date +%s)` for a unique name