### PR TITLE
Remove redundant skills/ directory from documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,6 @@ This repository captures reusable skills for AI coding agents. Agent guidance fo
 ## Structure
 
 ```
-skills/
 ├── AGENTS.md              # This file — agent guidance (agents.md standard)
 ├── LICENSE
 └── .agents/


### PR DESCRIPTION
## Summary
Updated the AGENTS.md documentation to remove an outdated directory reference from the repository structure diagram.

## Changes
- Removed the `skills/` directory entry from the ASCII structure diagram in AGENTS.md
- The diagram now accurately reflects the actual repository structure with only the relevant top-level files and directories

## Details
The `skills/` directory reference in the documentation structure was not aligned with the actual repository layout. This change ensures the AGENTS.md file provides accurate guidance to users about the repository's organization.

https://claude.ai/code/session_01VdDrCGVK25BGEBxPLdkmtD