### PR TITLE
Clarify skills management documentation and workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Skills live under `.agents/skills/` so that agents running within this repositor
 
 Each skill is a **directory** named after the skill containing a `SKILL.md` file with YAML frontmatter and Markdown instructions.
 
-For full format rules, naming constraints, progressive disclosure levels, and a worked example, use the **`skills`** skill or read `.agents/skills/skills/references/skill-format.md` directly.
+For full format rules, naming constraints, progressive disclosure levels, and a worked example, read `.agents/skills/skills/references/skill-format.md`. To create, update, or delete skills using guided steps, use the **`skills`** skill (`/skills`).
 
 ## Available Skills
 
@@ -40,7 +40,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 
 ## Adding or Managing Skills
 
-Use the **`skills`** skill — it covers creating, updating, and deleting skills with the correct conventions and commit messages.
+To create, update, or delete skills with guided steps and correct conventions, use the **`skills`** skill (`/skills`). To learn the skill format first, read `.agents/skills/skills/references/skill-format.md`.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
Updated AGENTS.md to provide clearer guidance on skill management by reorganizing information about the skills skill and skill format documentation.

## Key Changes
- Restructured the "Skills" section to separate format reference documentation from the interactive skill management tool
- Added command syntax (`/skills`) to make the skills skill invocation more explicit
- Reorganized the "Adding or Managing Skills" section to:
  - Lead with the interactive skills skill for guided management workflows
  - Reference the format documentation as a prerequisite for understanding skill structure
  - Clarify the distinction between learning the format and performing skill operations

## Notable Details
- Improved information architecture by making it clearer that users can either read documentation directly or use the guided interactive tool
- Added explicit command reference (`/skills`) to help users understand how to invoke the skill
- Maintained all existing information while improving clarity and logical flow

https://claude.ai/code/session_017qUupJcrsfF6rL7bMoy6oD