### PR TITLE
skills skill: add when-to-invoke clause to description

### DIFF
--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: skills
 description: >
-  Creates, updates, and manages reusable agent skills.
+  Creates, updates, and manages reusable agent skills stored under
+  .agents/skills/. Invoke when the user wants to add, modify, rename,
+  delete, or audit skills in this repository.
 license: Apache-2.0
 metadata:
   author: geemus


### PR DESCRIPTION
## Summary
- Expands the `skills` skill frontmatter description to include a "when to invoke" clause
- Fixes violation of the skill-format.md spec requiring descriptions to cover both *what* the skill does and *when* to invoke it

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)