### PR TITLE
Add .gitignore to exclude .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.gitignore` to prevent `.claude/worktrees/` from being tracked in git

## Test plan
- [ ] Verify `.claude/worktrees/` is ignored by git after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)