### PR TITLE
docs: adopt conventional commits standard

### DIFF
--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -25,7 +25,7 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 5. Write a clear Markdown body with instructions agents can follow directly
 6. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
 7. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
-8. Commit: `add <skill-name> skill: <one-line summary>`
+8. Commit: `feat(<skill-name>): add <skill-name> skill — <one-line summary>`
 
 ### Updating a skill
 
@@ -33,14 +33,14 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 2. Keep the `name` field in sync with the directory name — never rename one without the other
 3. Update `metadata.version` when the instructions change meaningfully
 4. Review `AGENTS.md` — update if the changes affect anything documented there
-5. Commit: `update <skill-name> skill: <one-line summary of change>`
+5. Commit: `feat(<skill-name>):` or `fix(<skill-name>):` or `docs(<skill-name>):` depending on the nature of the change, followed by a lowercase imperative description
 
 ### Deleting a skill
 
 1. Confirm with the user before deleting
 2. Remove the entire `.agents/skills/<skill-name>/` directory
 3. Review `AGENTS.md` — remove any references to the deleted skill
-4. Commit: `remove <skill-name> skill: <reason>`
+4. Commit: `chore(<skill-name>): remove <skill-name> skill — <reason>`
 
 ### Reviewing / auditing skills
 
@@ -48,7 +48,7 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 - Validate a skill: check that `SKILL.md` exists, frontmatter has `name` and `description`, `name` matches the directory
 - For full format rules, see `references/skill-format.md`
 - If the audit is read-only and no issues are found, no commit is needed
-- If audit findings require corrections, apply fixes and commit: `fix <skill-name> skill: <description of issue corrected>`
+- If audit findings require corrections, apply fixes and commit: `fix(<skill-name>): <description of issue corrected>`
 
 ## Progressive Disclosure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,14 @@ To create, update, or delete skills with guided steps and correct conventions, u
 
 - Default branch: `main`
 - Feature branches: `<author>/<short-description>` or `claude/<task-slug>`
-- Commit messages: imperative mood, lowercase, no trailing period
+- Commit messages: [Conventional Commits](https://www.conventionalcommits.org) format — `<type>[optional scope]: <description>` — where description is lowercase imperative mood with no trailing period
+  - Valid types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+  - Scope (optional): the skill name or component affected, e.g. `feat(plan):`, `fix(skills):`
+  - Examples:
+    - `docs: adopt conventional commits standard`
+    - `feat(skills): add loop skill`
+    - `fix(plan): correct frontmatter validation logic`
+    - `chore: update AGENTS.md structure`
 - Do not force-push to `main`
 
 ## Code Style & Conventions


### PR DESCRIPTION
## Summary
- Updates `AGENTS.md` git workflow section to specify Conventional Commits format with valid types, optional scope, and examples
- Updates `skills/SKILL.md` commit guidance to use conventional commit types (`feat`, `fix`, `chore`, `docs`) for create/update/delete/audit operations

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)