### PR TITLE
feat(conventional-comments): add conventional-comments skill

### DIFF
--- a/.agents/skills/conventional-comments/SKILL.md
+++ b/.agents/skills/conventional-comments/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: conventional-comments
+description: >
+  Formats code review and PR feedback using the Conventional Comments standard
+  (label [decorations]: subject). Apply proactively whenever posting review
+  comments, inline feedback, or any critique of code or pull requests.
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Conventional Comments
+
+Formats review and feedback comments using the [Conventional Comments](https://conventionalcomments.org/) standard so that intent is unambiguous — readers know immediately whether a comment is blocking, optional, or informational.
+
+## When to apply
+
+Apply this format **proactively** whenever you:
+- Post a PR review comment (inline or summary)
+- Provide feedback on code, architecture, or a document
+- Suggest a change or improvement in a review context
+
+You do not need to be explicitly asked. If you are reviewing anything, use this format.
+
+## Format
+
+```
+label [decorations]: subject
+
+[body]
+
+[discussion reference]
+```
+
+- **label** — the comment's intent (see reference for full list)
+- **decorations** — optional modifiers in brackets, comma-separated (e.g. `[blocking, if-minor]`)
+- **subject** — a short summary; the main message
+- **body** — optional elaboration, reasoning, or examples
+- **discussion reference** — optional link to a related issue, PR, or discussion
+
+## Core labels
+
+| Label | Intent |
+|-------|--------|
+| `praise` | Highlights something positive; never blocking |
+| `nitpick` | Minor style/preference issue; non-blocking by default |
+| `suggestion` | Proposes an improvement; non-blocking by default |
+| `issue` | Points out a problem that must be addressed; blocking by default |
+| `todo` | Small, unambiguous task the author should complete |
+| `question` | Asks for clarification; non-blocking |
+| `thought` | Shares an idea that doesn't warrant action |
+| `chore` | Simple housekeeping (rename, move, reformat); non-blocking |
+| `note` | Informational; no action required |
+
+For the full label and decoration reference, read `references/conventional-comments-spec.md`.
+
+## Quick examples
+
+```
+praise: clean abstraction here — easy to follow
+
+suggestion: consider extracting this into a helper so it can be reused
+
+issue [blocking]: this will panic on nil input; add a nil check before dereferencing
+
+question: why is this sorted descending? just want to make sure it's intentional
+
+nitpick: s/recieve/receive/
+```
+
+## Progressive Disclosure
+
+| Level | Content | When to load |
+|-------|---------|--------------|
+| 1 | `name` + `description` | Always |
+| 2 | `SKILL.md` body (this file) | When posting review comments |
+| 3 | `references/conventional-comments-spec.md` | When you need the full label/decoration list |

--- a/.agents/skills/conventional-comments/references/conventional-comments-spec.md
+++ b/.agents/skills/conventional-comments/references/conventional-comments-spec.md
@@ -1,0 +1,137 @@
+# Conventional Comments — Full Specification
+
+Source: [conventionalcomments.org](https://conventionalcomments.org/)
+
+## Format
+
+```
+label [decorations]: subject
+
+[body]
+
+[discussion reference]
+```
+
+Every part after `label` is optional, but `subject` should almost always be present.
+
+---
+
+## Labels
+
+### `praise`
+Highlights something positive about the code or design. Never blocking. Use to acknowledge good work and encourage the author.
+
+```
+praise: elegant use of the iterator pattern here
+```
+
+### `nitpick`
+A minor style, naming, or preference issue that does not affect correctness. Non-blocking by default. The author may address it at their discretion.
+
+```
+nitpick: variable name `tmp` could be more descriptive
+```
+
+### `suggestion`
+Proposes a concrete improvement. Non-blocking by default; the author should consider it but is not required to act. Include enough detail for the author to evaluate the trade-off.
+
+```
+suggestion: consider caching this result — it's computed on every render
+
+You could memoize with `useMemo` keyed on `userId`.
+```
+
+### `issue`
+Points out a problem that must be addressed before merging. **Blocking by default.** Be specific about what is wrong and, where possible, how to fix it.
+
+```
+issue: this loop will run indefinitely if `items` is empty; add a guard or change the condition
+```
+
+### `todo`
+A small, clearly scoped task the author should complete. Usually non-blocking unless decorated. Distinct from `issue` in that it is unambiguous and easy to execute.
+
+```
+todo: remove this debug log before merging
+```
+
+### `question`
+Requests clarification without implying anything is wrong. Non-blocking. The author should answer but is not required to change code.
+
+```
+question: is this intentionally case-sensitive, or should we normalise to lowercase first?
+```
+
+### `thought`
+Shares an idea or observation that doesn't warrant any action. Non-blocking. Use when you want to surface a consideration without creating pressure to act.
+
+```
+thought: if we ever need to support multiple currencies, this will need to change — not a concern now
+```
+
+### `chore`
+Routine housekeeping: rename, reformat, move, update a comment. Non-blocking by default.
+
+```
+chore: update the docstring to reflect the new parameter name
+```
+
+### `note`
+Provides context or information the author or reviewer may find useful. Non-blocking; no action required.
+
+```
+note: this mirrors the pattern used in `auth/middleware.go` — keeping it consistent is intentional
+```
+
+---
+
+## Decorations
+
+Decorations appear in brackets immediately after the label, comma-separated.
+
+| Decoration | Meaning |
+|------------|---------|
+| `blocking` | Must be resolved before the PR can merge (overrides a label's default) |
+| `non-blocking` | Does not need to be resolved before merging (overrides a label's default) |
+| `if-minor` | Blocking only if the change required is small; author's call |
+| `security` | Has security implications; treat with extra care |
+| `performance` | Relates to performance or efficiency |
+| `accessibility` | Relates to a11y concerns |
+
+### Combining decorations
+
+```
+issue [non-blocking, if-minor]: variable shadowing — harmless here, but can confuse readers
+```
+
+```
+suggestion [blocking, security]: user input is interpolated directly into the SQL query — use a parameterised query instead
+```
+
+---
+
+## Blocking vs. non-blocking defaults
+
+| Label | Default |
+|-------|---------|
+| `praise` | non-blocking |
+| `nitpick` | non-blocking |
+| `suggestion` | non-blocking |
+| `issue` | **blocking** |
+| `todo` | non-blocking |
+| `question` | non-blocking |
+| `thought` | non-blocking |
+| `chore` | non-blocking |
+| `note` | non-blocking |
+
+Use `[blocking]` or `[non-blocking]` decorations to override the default.
+
+---
+
+## Tips
+
+- Keep the **subject** to one line; move elaboration to the **body**.
+- A comment without a label is ambiguous — always label.
+- Prefer `suggestion` over `issue` when you are not certain something is wrong.
+- Use `praise` freely; positive signals are as useful as critical ones.
+- When a comment references an external discussion, link it at the end of the body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 |-------|---------|---------|
 | `skills` | `/skills` | Create, update, and manage skills in this repository |
 | `plan` | `/plan` | Generate a structured work plan and write it to a GitHub issue |
+| `conventional-comments` | applied proactively during code review | Format review and feedback comments using the Conventional Comments standard |
 
 ## Adding or Managing Skills
 


### PR DESCRIPTION
## Summary

- Adds `.agents/skills/conventional-comments/SKILL.md` with frontmatter, proactive trigger guidance, core label table, and quick examples
- Adds `.agents/skills/conventional-comments/references/conventional-comments-spec.md` with full label/decoration reference
- Updates `AGENTS.md` skills table with the new skill

Closes #20

## Test plan

- [x] `ls .agents/skills/conventional-comments/` — skill directory exists
- [x] `grep -E "^name:|^description:" .agents/skills/conventional-comments/SKILL.md` — required frontmatter present
- [x] `ls .agents/skills/conventional-comments/references/conventional-comments-spec.md` — reference file exists
- [x] `grep "conventional-comments" AGENTS.md` — AGENTS.md updated
- [x] `name` field matches directory name
- [x] `SKILL.md` body stays well under 5,000 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)