### PR TITLE
docs: remove progressive disclosure tables; update skills description

### DIFF
--- a/.agents/skills/conventional-comments/SKILL.md
+++ b/.agents/skills/conventional-comments/SKILL.md
@@ -69,10 +69,3 @@ question: why is this sorted descending? just want to make sure it's intentional
 nitpick: s/recieve/receive/
 ```
 
-## Progressive Disclosure
-
-| Level | Content | When to load | Target size |
-|-------|---------|--------------|-------------|
-| 1 | `name` + `description` | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body (this file) | When posting review comments | < 5,000 tokens |
-| 3 | `references/conventional-comments-spec.md` | When you need the full label/decoration list | Unlimited |

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -143,6 +143,14 @@ Fetches issue #35, generates an updated plan, edits the issue in place, and post
 ```
 Same as above; repo is extracted from the URL.
 
+## Progressive Disclosure
+
+| Level | Content | When to load | Target size |
+|-------|---------|--------------|-------------|
+| 1 | `name` + `description` | Always (startup) | ~100 tokens |
+| 2 | `SKILL.md` body (this file) | When skill is triggered | < 5,000 tokens |
+| 3 | None currently defined | — | — |
+
 **Generated issue body structure:**
 ```markdown
 ## Objective

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -143,14 +143,6 @@ Fetches issue #35, generates an updated plan, edits the issue in place, and post
 ```
 Same as above; repo is extracted from the URL.
 
-## Progressive Disclosure
-
-| Level | Content | When to load | Target size |
-|-------|---------|--------------|-------------|
-| 1 | `name` + `description` | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body (this file) | When skill is triggered | < 5,000 tokens |
-| 3 | None currently defined | — | — |
-
 **Generated issue body structure:**
 ```markdown
 ## Objective

--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -72,12 +72,4 @@ Expected: agent reads existing `SKILL.md`, updates the `description` frontmatter
 
 Expected: agent confirms with user, removes `.agents/skills/pdf/` directory, updates `AGENTS.md` if needed, commits with `chore(pdf): remove pdf skill — no longer used`
 
-## Progressive Disclosure
-
-| Level | Content | When to load | Target size |
-|-------|---------|--------------|-------------|
-| 1 | `name` + `description` | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body (this file) | When skill is triggered | < 5,000 tokens |
-| 3 | `scripts/`, `references/`, `assets/` | On demand, when you need format details, examples, or executables | Unlimited |
-
 Read `references/skill-format.md` for complete frontmatter rules, naming constraints, and a full worked example.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 
 | Skill | Trigger | Purpose |
 |-------|---------|---------|
-| `skills` | `/skills` | Create, update, and manage skills in this repository |
+| `skills` | `/skills` | Create, update, manage, and audit skills in this repository |
 | `plan` | `/plan` | Generate a structured work plan and write it to a GitHub issue |
 | `conventional-comments` | applied proactively during code review | Format review and feedback comments using the Conventional Comments standard |
 


### PR DESCRIPTION
## Summary

- Remove Progressive Disclosure tables from all three skills (`skills`, `plan`, `conventional-comments`) — the tables repeated boilerplate already defined in the spec and added noise (especially `plan`'s "None currently defined" Level 3 row); inline references in the instructions already point agents to Level 3 content at the right moment
- Update `AGENTS.md` skills table description to mention auditing, matching the skill's actual capability

## Test plan

- [ ] Verify all three `SKILL.md` files no longer contain a Progressive Disclosure section
- [ ] Verify `conventional-comments/SKILL.md` still has inline reference to `references/conventional-comments-spec.md`
- [ ] Verify `skills/SKILL.md` still has inline reference to `references/skill-format.md`
- [ ] Verify `AGENTS.md` skills row reads "Create, update, manage, and audit skills in this repository"