### PR TITLE
feat(skills): add naming convention guidance and description best practices

### DIFF
--- a/.agents/skills/skills/SKILL.md
+++ b/.agents/skills/skills/SKILL.md
@@ -7,7 +7,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Skills
@@ -18,9 +18,13 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 
 ### Creating a skill
 
-1. Choose a name: lowercase letters, numbers, and hyphens only; 1–64 chars; must be unique under `.agents/skills/`
+1. Choose a name — it must pass all of the following checks:
+   - **Format**: lowercase letters, digits, and hyphens only; 1–64 chars; no leading, trailing, or consecutive hyphens; must be unique under `.agents/skills/`
+   - **Quality**: use an action+object formula (`search-orders`, `extract-pdf-text`); avoid single-word or noun-only names; name the outcome, not the implementation; avoid reserved words (`anthropic`, `claude`)
+   - **Namespace**: if the repository already has 10 or more skills, add a shared prefix for related skills (e.g. `orders-search`, `orders-refund`)
+   - For the full naming specification and worked example, read `references/skill-format.md`
 2. Create the directory: `.agents/skills/<skill-name>/`
-3. Create `SKILL.md` — required frontmatter fields: `name` (must match directory), `description` (what it does and when to use it); for full specification and worked example, read `references/skill-format.md`
+3. Create `SKILL.md` — required frontmatter fields: `name` (must match directory), `description` (what it does and when to use it); use the **"Does X. Use when Y."** template — start with the action verb in third person, then state the triggering condition; for full specification and worked example, read `references/skill-format.md`
 4. Omit `allowed-tools` unless the user explicitly requests tool restrictions
 5. Write a clear Markdown body with instructions agents can follow directly
 6. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
@@ -50,6 +54,12 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
    - Frontmatter contains `name` and non-empty `description`
    - `name` value matches the parent directory name exactly
    - `description` describes both what the skill does and when to invoke it
+   - **Quality checks**:
+     - `name` is not generic or noun-only (e.g. `helper`, `utils`, `data`, `files`)
+     - `name` uses action+object or gerund form, not an implementation detail (e.g. not `run-bert-v2`)
+     - `description` opens with an active-voice verb in third person, not *"This skill…"* or *"A helper…"*
+     - `description` explicitly states a triggering condition (*"Use when…"*)
+     - If the repository has 10+ skills, check that related skills share a namespace prefix
 3. For complete format rules and validation criteria, read `references/skill-format.md`
 4. Auto-fix minor issues (typos, table formatting, missing optional metadata fields); ask the user before removing or renaming skills
 5. If the audit is read-only and no issues are found, no commit is needed

--- a/.agents/skills/skills/references/skill-format.md
+++ b/.agents/skills/skills/references/skill-format.md
@@ -38,11 +38,27 @@ allowed-tools:            # optional: restrict tool access within the skill
 - No leading, trailing, or consecutive hyphens
 - Must match the parent directory name exactly
 
+#### Semantic quality rules
+
+- **Action + object formula**: prefer `search-orders`, `analyze-sentiment`, `generate-report` over vague single words
+- **Gerund form acceptable**: `processing-pdfs`, `extracting-metadata` are valid when they read naturally
+- **Specificity over brevity**: single-word names are almost always too vague — `pdf` says nothing about what happens to the PDF
+- **Name for outcome, not implementation**: use `analyze-sentiment` not `run-bert-v2`; callers should not need to know the underlying tool or model
+- **Avoid reserved words**: do not use `anthropic`, `claude`, or other trademark terms as the skill name or prefix
+- **Namespace prefixes for large repos**: when a repository has 10 or more skills, prefix related skills with a shared namespace (e.g. `orders-search`, `orders-refund`) to make discovery easier and prevent name collisions
+
 ### `description` rules
 
 - Non-empty; maximum 1024 characters
 - Written in third person (agents read this for discovery)
 - Must describe both *what* the skill does and *when* to invoke it
+
+#### Description best practices
+
+- **"Does X. Use when Y." template**: open with what the skill does, then explicitly state the triggering condition. Example: *"Extracts text from PDF files. Use when the user asks to read, parse, or summarize a PDF document."*
+- **Third person, active voice, start with the action verb**: write *"Generates …"* not *"This skill will generate …"* or *"Can be used to generate …"*
+- **Include trigger keywords and synonyms**: if users might phrase the request multiple ways, mention the synonyms so agent discovery works reliably (e.g. *"… also triggered by requests to OCR or convert PDFs"*)
+- **Explicitly distinguish overlapping skills**: if two skills handle similar inputs, call out the difference in each description so the agent picks the right one
 
 ### `allowed-tools` rules
 
@@ -94,10 +110,10 @@ Keep `SKILL.md` lean. Move large examples, schemas, and reference docs into `ref
 
 ## Worked Example
 
-Directory: `.agents/skills/pdf/`
+Directory: `.agents/skills/extract-pdf-text/`
 
 ```
-pdf/
+extract-pdf-text/
 ├── SKILL.md
 └── references/
     └── pdfminer-api.md
@@ -107,17 +123,17 @@ pdf/
 
 ```markdown
 ---
-name: pdf
+name: extract-pdf-text
 description: >
-  Extracts and summarizes content from PDF files. Use when the user
-  asks to read, parse, or extract text from a PDF document.
+  Extracts and summarizes text content from PDF files. Use when the user
+  asks to read, parse, extract, or summarize text from a PDF document.
 license: Apache-2.0
 metadata:
   author: geemus
   version: "1.0"
 ---
 
-# PDF
+# Extract PDF Text
 
 Extracts text and metadata from PDF files using pdfminer.
 
@@ -137,3 +153,15 @@ For full API details, read `references/pdfminer-api.md`.
 - Never commit secrets, tokens, or credentials inside a skill
 - Skills that call external services must document required environment variables in `SKILL.md`
 - Skills performing destructive operations must include an explicit confirmation step
+
+### Anti-patterns
+
+Avoid these common mistakes when naming and describing skills:
+
+| Anti-pattern | Example | Problem | Better alternative |
+|---|---|---|---|
+| Generic names | `helper`, `utils`, `tools` | Conveys no useful information for discovery | Name what the skill specifically does: `format-date`, `validate-email` |
+| Noun-only names | `data`, `files`, `report` | Does not indicate what action is taken | Add the verb: `fetch-data`, `archive-files`, `generate-report` |
+| Implementation-detail names | `run-bert-v2`, `call-gpt4` | Breaks callers when the implementation changes | Name the outcome: `analyze-sentiment`, `summarize-text` |
+| Mixed casing | `SearchOrders`, `search_orders` | Violates the lowercase-kebab-case format rule | `search-orders` |
+| Vague description openers | *"This skill can be used to…"*, *"A helper that…"* | Wastes the first tokens agents read; passive and weak | Start with the action verb: *"Searches orders by…"* |


### PR DESCRIPTION
Expands the skills skill with semantic quality rules for skill names,
description best practices using the "Does X. Use when Y." template,
an anti-patterns reference table, and a worked example rename
(pdf → extract-pdf-text). Audit checklist now includes quality checks.
Bumps skills SKILL.md version to 1.1.

Closes #53