### PR TITLE
docs(manage-skills): add natural language trigger guidance to skill format and workflow

### DIFF
--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -7,7 +7,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Manage Skills
@@ -25,20 +25,22 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
    - For the full naming specification and worked example, read `references/skill-format.md`
 2. Create the directory: `.agents/skills/<skill-name>/`
 3. Create `SKILL.md` — required frontmatter fields: `name` (must match directory), `description` (what it does and when to use it); use the **"Does X. Use when Y."** template — start with the action verb in third person, then state the triggering condition; for full specification and worked example, read `references/skill-format.md`
-4. Omit `allowed-tools` unless the user explicitly requests tool restrictions
-5. Write a clear Markdown body with instructions agents can follow directly
-6. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
-7. Apply the `refine-prose` skill to the `description` frontmatter field and the `SKILL.md` body — run it silently before saving
-8. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
-9. Commit: `feat(<skill-name>): add <skill-name> skill — <one-line summary>`
+4. Document natural-language trigger phrases in the `description` — include the phrases users are likely to say (e.g. *"create a commit"*, *"review this PR"*, *"make a plan"*). Use the inline `Use when...` form for simple skills; add explicit `TRIGGER when:` / `DO NOT TRIGGER when:` lines when the skill overlaps with others and disambiguation is needed. See the Natural Language Triggers section in `references/skill-format.md` for both patterns and concrete examples.
+5. Omit `allowed-tools` unless the user explicitly requests tool restrictions
+6. Write a clear Markdown body with instructions agents can follow directly
+7. Add `scripts/`, `references/`, or `assets/` subdirectories only when needed for Level 3 content
+8. Apply the `refine-prose` skill to the `description` frontmatter field and the `SKILL.md` body — run it silently before saving
+9. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
+10. Commit: `feat(<skill-name>): add <skill-name> skill — <one-line summary>`
 
 ### Updating a skill
 
 1. Read the existing `SKILL.md` before making changes
 2. Keep the `name` field in sync with the directory name — never rename one without the other
 3. Update `metadata.version` when the instructions change meaningfully
-4. Review `AGENTS.md` — update if the changes affect anything documented there
-5. Commit: `feat(<skill-name>):` or `fix(<skill-name>):` or `docs(<skill-name>):` depending on the nature of the change, followed by a lowercase imperative description
+4. If touching the `description`, review the natural-language trigger phrases — ensure the `Use when...` condition and any `TRIGGER when:` / `DO NOT TRIGGER when:` lines reflect the updated skill scope. See the Natural Language Triggers section in `references/skill-format.md` for guidance.
+5. Review `AGENTS.md` — update if the changes affect anything documented there
+6. Commit: `feat(<skill-name>):` or `fix(<skill-name>):` or `docs(<skill-name>):` depending on the nature of the change, followed by a lowercase imperative description
 
 ### Deleting a skill
 

--- a/.agents/skills/manage-skills/references/skill-format.md
+++ b/.agents/skills/manage-skills/references/skill-format.md
@@ -60,6 +60,34 @@ allowed-tools:            # optional: restrict tool access within the skill
 - **Include trigger keywords and synonyms**: if users might phrase the request multiple ways, mention the synonyms so agent discovery works reliably (e.g. *"… also triggered by requests to OCR or convert PDFs"*)
 - **Explicitly distinguish overlapping skills**: if two skills handle similar inputs, call out the difference in each description so the agent picks the right one
 
+#### Natural Language Triggers
+
+The `description` field is the primary discovery mechanism — agents match it against user phrasing at session startup. Trigger phrases are the natural-language expressions users actually say that should activate the skill.
+
+**Two patterns for documenting triggers:**
+
+1. **`Use when...` (inline)** — embed the triggering condition directly in the description. Best for simple, unambiguous skills:
+   > *"Generates a structured work plan. Use when the user asks to create a plan, define tasks, or scope out work."*
+
+2. **`TRIGGER when` / `DO NOT TRIGGER when` (explicit block)** — add structured lines after the description for skills that overlap with others or need clear disambiguation:
+   > *"Stages changes and creates a conventional commit message.*
+   > *TRIGGER when: user asks to commit, stage files, write a commit message, or save changes.*
+   > *DO NOT TRIGGER when: user asks to push, open a PR, or create a branch."*
+
+**Concrete examples:**
+
+| User says | Skill triggered | Key phrases in description |
+|-----------|----------------|---------------------------|
+| "create a commit", "save my changes", "commit this" | `create-commit` | *commit, stage files, write a commit message* |
+| "review this PR", "can you audit this diff" | `review-pr` | *pull request review, audit a diff* |
+| "make a plan", "create plan skill", "scope out this work" | `create-plan` | *work plan, scope out, define tasks* |
+| "clean up this draft", "polish my writing" | `refine-prose` | *polish prose, clarity, written output* |
+
+**Tips:**
+- Include synonyms users might say: *"commit"* and *"save changes"* should both trigger `create-commit`
+- For overlapping skills, `DO NOT TRIGGER when` prevents the wrong skill from firing
+- Natural phrasing (*"can you review this PR"*) should match as reliably as a direct slash command (*"/review-pr"*)
+
 ### `allowed-tools` rules
 
 Omit unless the user explicitly requests tool restrictions. Restricting tools limits the agent's ability to handle unexpected situations; only add this field when there is a specific reason to do so.


### PR DESCRIPTION
Expand skill-format.md with a dedicated Natural Language Triggers subsection
covering the Use when... inline pattern and the TRIGGER when / DO NOT TRIGGER when
block pattern, with a concrete example table mapping user phrases to skills.

Add explicit trigger-phrase steps to the manage-skills creating and updating
workflows, and bump metadata.version to 1.3.