### PR TITLE
fix(skills): improve natural language triggers across all skills

### DIFF
--- a/.agents/skills/create-commit/SKILL.md
+++ b/.agents/skills/create-commit/SKILL.md
@@ -2,13 +2,14 @@
 name: create-commit
 description: >
   Stages changes safely, generates a conventional-commit message from the diff,
-  and blocks secrets or debug artifacts from being committed. Use when the user
-  wants to commit work — also triggered by requests to stage files, write a
-  commit message, or run git commit.
+  and blocks secrets or debug artifacts from being committed.
+  TRIGGER when: user asks to commit, save changes, stage files, write a commit
+  message, or run git commit.
+  DO NOT TRIGGER when: user asks to push, open a PR, or create a branch.
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Create Commit

--- a/.agents/skills/create-plan/SKILL.md
+++ b/.agents/skills/create-plan/SKILL.md
@@ -2,21 +2,21 @@
 name: create-plan
 description: >
   Generates a detailed, structured work plan from a description of work to be
-  done, then creates or updates a GitHub issue containing the plan. Interactive:
-  asks clarifying questions when needed and presents the plan for review. Invoke
-  when the user wants to plan out a feature, bug fix, project, or any body of
-  work and capture it as a GitHub issue for tracking and collaboration. Also
-  supports update mode: when invoked with an existing issue number or URL,
-  updates that issue in place and posts a change-summary comment.
+  done, then creates or updates a GitHub issue containing the plan. Use when the
+  user wants to plan out a feature, bug fix, project, or any body of work —
+  also triggered by "make a plan", "scope out this work", "break down this
+  task", "help me plan", or "create a GitHub issue for this". Supports update
+  mode: when given an existing issue number or URL, updates that issue in place
+  and posts a change-summary comment.
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Plan
 
-Turns a description of work into a structured, executable plan written to a GitHub issue. Supports both create mode (new issue) and update mode (edit an existing issue in place).
+Turns a description of work into a structured, executable plan written to a GitHub issue. Interactive: asks clarifying questions when needed and presents the plan for review before writing. Supports both create mode (new issue) and update mode (edit an existing issue in place).
 
 ## Instructions
 

--- a/.agents/skills/format-review-comments/SKILL.md
+++ b/.agents/skills/format-review-comments/SKILL.md
@@ -3,11 +3,13 @@ name: format-review-comments
 description: >
   Formats code review and PR feedback using the Conventional Comments standard
   (label [decorations]: subject). Apply proactively whenever posting review
-  comments, inline feedback, or any critique of code or pull requests.
+  comments, inline feedback, or any critique of code or pull requests. Also
+  invoke directly when the user asks to format feedback, use conventional
+  comments style, or label a review comment as blocking, suggestion, or nitpick.
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Conventional Comments

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -2,12 +2,14 @@
 name: manage-skills
 description: >
   Creates, updates, and manages reusable agent skills stored under
-  .agents/skills/. Invoke when the user wants to add, modify, rename,
-  delete, or audit skills in this repository.
+  .agents/skills/. Use when the user wants to add, modify, rename, delete, or
+  audit skills in this repository — also triggered by "create a new skill",
+  "set up a skill", "list my skills", "what skills do I have", or "remove a
+  skill".
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.3"
+  version: "1.4"
 ---
 
 # Manage Skills

--- a/.agents/skills/refine-prose/SKILL.md
+++ b/.agents/skills/refine-prose/SKILL.md
@@ -4,12 +4,14 @@ description: >
   Polishes drafted prose for clarity, conciseness, and consistent voice before
   it is recorded or posted. Apply after drafting any plan, review summary, or
   written output to catch filler phrases, passive constructions, and
-  inconsistent terminology. Invoke directly with /refine-prose or reference
-  from other skills as a composable refinement step.
+  inconsistent terminology. Use when the user asks to polish, clean up, improve,
+  edit, or tighten writing — also triggered by "refine this draft", "make this
+  clearer", or "improve my writing". Reference from other skills as a composable
+  refinement step.
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Refine Prose

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -3,12 +3,14 @@ name: review-pr
 description: >
   Guides systematic pull request review across logic, security, performance,
   test coverage, and documentation. Uses the format-review-comments skill to
-  format all feedback. Invoke when the user asks to review a pull request,
-  audit a diff, or give structured feedback on proposed code changes.
+  format all feedback. Use when the user asks to review a pull request, audit a
+  diff, or give structured feedback on proposed code changes — also triggered by
+  "look at this PR", "check PR #N", "can you review this", or "give feedback on
+  this diff".
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Review PR


### PR DESCRIPTION
- create-commit: replace inline Use when with TRIGGER/DO NOT TRIGGER block
  to prevent misfires on push and PR requests
- format-review-comments: add user-facing trigger phrases for direct invocation
- refine-prose: add synonym keywords (polish, clean up, improve, edit, tighten)
- manage-skills: align to Use when template; add list/create/remove synonyms
- review-pr: add casual phrasings (look at this PR, check PR #N, give feedback)
- create-plan: move behavioral note to body; add scope/plan/break-down synonyms

https://claude.ai/code/session_01Bx6uX1t433viQtCPvGrG21