### PR TITLE
feat: add claude code plugin manifest and supporting files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "skills",
+  "description": "Reusable agent skills for Claude Code — commit safety, plan generation, PR review, prose refinement, and more.",
+  "version": "1.0.0",
+  "author": "geemus",
+  "license": "MIT",
+  "repository": "https://github.com/geemus/skills",
+  "keywords": ["claude", "skills", "agent", "agentskills", "productivity"],
+  "skills": "./.agents/skills/"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,13 @@ This repository captures reusable skills for AI coding agents. Agent guidance fo
 
 ```
 ├── AGENTS.md              # This file — agent guidance (agents.md standard)
+├── CHANGELOG.md           # Version history
 ├── LICENSE
+├── README.md              # Installation and usage reference
+├── .claude/
+│   └── skills -> ../.agents/skills   # Symlink for standalone Claude Code use
+├── .claude-plugin/
+│   └── plugin.json        # Claude Code plugin manifest
 └── .agents/
     └── skills/
         └── <skill-name>/          # Each skill is a directory
@@ -23,6 +29,24 @@ This repository captures reusable skills for AI coding agents. Agent guidance fo
 ```
 
 Skills live under `.agents/skills/` so that agents running within this repository discover them automatically via standard agent runtime conventions.
+
+## Plugin Installation
+
+This repository ships a Claude Code plugin manifest at `.claude-plugin/plugin.json`. The manifest points to `.agents/skills/` and registers skills under the `skills` namespace (e.g. `/skills:create-plan`).
+
+**Install via plugin directory:**
+
+```sh
+claude --plugin-dir /path/to/skills
+```
+
+**Install from the repository URL** (once Claude Code supports remote plugin installation):
+
+```sh
+claude plugin install https://github.com/geemus/skills
+```
+
+**Standalone use** (without plugin namespace): the `.claude/skills` symlink provides backward-compatible skill discovery for agents running within this repository.
 
 ## Skills Format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-04-06
+
+### Added
+
+- Six production-ready skills: `create-commit`, `create-plan`, `format-review-comments`, `manage-skills`, `refine-prose`, `review-pr`
+- `.claude-plugin/plugin.json` manifest enabling installation via `claude --plugin-dir` and `claude plugin install`
+- `README.md` with installation instructions and per-skill usage reference
+- `.claude/skills` symlink for backward-compatible standalone Claude Code discovery
+- Reference materials: `skill-format.md`, `conventional-comments-spec.md`, `secret-patterns.md`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# skills
+
+Reusable agent skills for Claude Code and other AI coding agents. Follows the [agentskills.io](https://agentskills.io) open standard and ships a native [Claude Code plugin manifest](https://docs.claude.ai/code/plugins) for one-command installation.
+
+## Skills
+
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| `manage-skills` | `/skills:manage-skills` | Create, update, manage, and audit skills in this repository |
+| `create-plan` | `/skills:create-plan` | Generate a structured work plan and write it to a GitHub issue |
+| `format-review-comments` | applied proactively during code review | Format review and feedback comments using the Conventional Comments standard |
+| `review-pr` | `/skills:review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
+| `create-commit` | `/skills:commit` | Stage changes safely, generate a conventional-commit message, and block secrets from being committed |
+| `refine-prose` | `/skills:refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
+
+## Installation
+
+### Claude plugin (recommended)
+
+Install from a local clone using `--plugin-dir`:
+
+```sh
+git clone https://github.com/geemus/skills
+claude --plugin-dir ./skills
+```
+
+Or install directly from the repository URL once Claude Code supports remote plugin installation:
+
+```sh
+claude plugin install https://github.com/geemus/skills
+```
+
+Skills are registered under the `skills` namespace (e.g. `/skills:create-plan`). Run `/help` inside Claude Code to see all available commands.
+
+### Standalone Claude Code use
+
+If you already have the repository checked out and want skills available without the plugin namespace, the `.claude/skills` symlink points to `.agents/skills/` for direct discovery by Claude Code:
+
+```sh
+# From within the repository, skills load automatically.
+# From another project, symlink or copy the skills directory:
+ln -s /path/to/skills/.agents/skills .claude/skills
+```
+
+## Repository structure
+
+```
+├── AGENTS.md                  # Agent guidance (agents.md standard)
+├── CHANGELOG.md               # Version history
+├── LICENSE
+├── README.md                  # This file
+├── .claude/
+│   └── skills -> ../.agents/skills   # Symlink for standalone Claude Code use
+├── .claude-plugin/
+│   └── plugin.json            # Claude Code plugin manifest
+└── .agents/
+    └── skills/
+        └── <skill-name>/      # One directory per skill
+            ├── SKILL.md       # Required: YAML frontmatter + instructions
+            ├── scripts/       # Optional: executable scripts
+            ├── references/    # Optional: reference materials
+            └── assets/        # Optional: templates and examples
+```
+
+## Contributing
+
+Skills follow the format defined in `.agents/skills/manage-skills/references/skill-format.md`. Use the `manage-skills` skill (`/skills:manage-skills`) to create or update skills with guided steps and validation.
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org): `<type>[scope]: <description>`.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
- Add .claude-plugin/plugin.json pointing skills path to .agents/skills/
- Add README.md with installation instructions and per-skill usage table
- Add CHANGELOG.md with initial 1.0.0 entry
- Update AGENTS.md to document plugin manifest location and install methods

Preserves .claude/skills symlink for backward-compatible standalone use.