### PR TITLE
feat(manage-sprites): add sprite lifecycle management skill

### DIFF
--- a/.agents/skills/manage-sprites/SKILL.md
+++ b/.agents/skills/manage-sprites/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: manage-sprites
+description: >
+  Provisions, operates, and maintains sprites.dev instances through the full
+  lifecycle: authenticate, create, execute commands, manage checkpoints, and
+  destroy. Use when the user asks to create a sprite, run a command on a sprite,
+  checkpoint or restore a sprite, open a shell on a sprite, or delete a sprite.
+  Also triggered by "spin up a sprite", "exec on my sprite", "snapshot my sprite",
+  "roll back my sprite", or "tear down a sprite".
+  TRIGGER when: user references sprite lifecycle operations, sprites.dev, or managing
+  remote sandbox instances.
+  DO NOT TRIGGER when: the user is operating from within a sprite and managing local
+  services or checkpoints — use sprite-env commands instead (see references/sprites-services.md).
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Manage Sprites
+
+Manages the full lifecycle of sprites.dev instances using the `sprite` CLI.
+
+For CLI command details, read `references/sprites-cli.md`.
+For internal service and checkpoint management from within a sprite, read `references/sprites-services.md`.
+
+## Instructions
+
+### 1. Confirm authentication
+
+Run `sprite list` to confirm auth is working. If it fails, run `sprite login` (browser flow) or `sprite auth setup --token <token>` (token flow) and wait for the user to complete it.
+
+### 2. Identify the target sprite
+
+- If the user specifies a sprite name or has run `sprite use`, proceed with that sprite.
+- If ambiguous, run `sprite list` and ask the user to confirm.
+- For commands that accept `-s <name>`, prefer the explicit flag over relying on an active sprite.
+
+### 3. Execute the requested lifecycle operation
+
+Follow the minimal path for the operation:
+
+**Create**
+```
+sprite create <name>
+```
+Optionally scope to an org: `sprite create -o <org> <name>`.
+After creation, run `sprite use <name>` if the user wants it set as the active sprite for the directory.
+
+**Execute a command**
+```
+sprite exec -s <name> <command> [args...]
+```
+For an interactive shell: `sprite console -s <name>`.
+
+**Checkpoint**
+```
+sprite checkpoint create -s <name>
+sprite checkpoint list -s <name>
+```
+Recommend creating a checkpoint before any risky change. Include a note about what state is being preserved.
+
+**Restore**
+```
+sprite restore <checkpoint-id>
+```
+Always confirm with the user before restoring — it drops the current session state.
+
+**Destroy**
+```
+sprite destroy <name>
+```
+Always confirm with the user before destroying — this is irreversible.
+
+### 4. Surface results
+
+Return command output directly. If a command fails, include the error output and suggest a remediation step (re-auth, check sprite name, verify org).
+
+## Examples
+
+**Create and exec:**
+```
+sprite create dev-sandbox
+sprite exec -s dev-sandbox echo hello
+```
+
+**Checkpoint before a risky change:**
+```
+sprite checkpoint create -s dev-sandbox
+# proceed with change
+```
+
+**Restore a checkpoint:**
+```
+sprite checkpoint list -s dev-sandbox
+sprite restore <checkpoint-id>
+```
+
+**Destroy:**
+```
+sprite destroy dev-sandbox
+```

--- a/.agents/skills/manage-sprites/references/sprites-cli.md
+++ b/.agents/skills/manage-sprites/references/sprites-cli.md
@@ -1,0 +1,75 @@
+# Sprite CLI Cheat Sheet
+
+Reference for the `sprite` CLI (external instance management). Run `sprite --help` or `sprite <command> --help` for full options.
+
+## Authentication
+
+```sh
+sprite login                          # Browser-based login (Fly.io)
+sprite auth setup --token <token>     # Token-based login (no browser)
+sprite org auth                       # Org token flow
+sprite logout                         # Remove local config
+```
+
+## Instance Lifecycle
+
+```sh
+sprite create <name>                  # Create a new sprite
+sprite create -o <org> <name>         # Create in a specific org
+sprite list                           # List all sprites (alias: ls)
+sprite list -o <org>                  # List sprites in an org
+sprite use <name>                     # Activate sprite for current directory
+sprite use --unset                    # Clear active sprite
+sprite destroy <name>                 # Destroy a sprite (irreversible)
+sprite destroy -o <org> <name>
+```
+
+## Execution
+
+```sh
+sprite exec <command> [args...]       # Run command in active sprite
+sprite exec -s <name> <command>       # Run command in named sprite
+sprite -o <org> -s <name> exec <cmd>  # Scoped to org and sprite
+sprite console                        # Interactive shell (active sprite)
+sprite console -s <name>              # Interactive shell (named sprite)
+```
+
+## Checkpoints
+
+```sh
+sprite checkpoint create              # Snapshot active sprite
+sprite checkpoint create -s <name>    # Snapshot named sprite
+sprite checkpoint list                # List checkpoints (alias: ls)
+sprite checkpoint list -s <name>
+sprite checkpoint info <id>           # Details for a specific checkpoint
+sprite restore <id>                   # Restore from checkpoint (drops session!)
+```
+
+## Networking & URL
+
+```sh
+sprite url                            # Show public URL for active sprite
+sprite url update --auth public       # Make URL public (open to internet)
+sprite url update --auth sprite       # Restrict to org members (default)
+sprite proxy <port> [port2...]        # Forward local ports to sprite
+```
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `-s <name>` | Target sprite by name |
+| `-o <org>` | Target org |
+| `--debug` | Debug logging to stdout |
+| `--debug=<file>` | Debug logging to file |
+
+## Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `SPRITE_VERSION_DEBUG=true` | Show detailed version check info |
+| `UPGRADE_CHECK=true` | Force version check (bypass 24-hour cache) |
+
+## Required Auth
+
+Authentication is handled out of band. Run `sprite login` or `sprite auth setup --token <token>` before issuing any other commands. Tokens can be scoped to an org via `sprite org auth`.

--- a/.agents/skills/manage-sprites/references/sprites-services.md
+++ b/.agents/skills/manage-sprites/references/sprites-services.md
@@ -1,0 +1,75 @@
+# Sprite Internal Services & Checkpoints
+
+Reference for `sprite-env` — the CLI available **from within a sprite instance** for managing local services, checkpoints, and environment info.
+
+> **Do not use MCP Sprite tools** (e.g. `checkpoint_create`, `service_start`). They target remote sprites by name and will fail inside a local instance. Use `sprite-env` exclusively.
+
+## Environment Info
+
+```sh
+sprite-env info           # Show instance ID, URL, org, active services
+```
+
+## Services
+
+Long-running processes managed by the sprite runtime. Services persist across reboots and restart automatically.
+
+```sh
+# Create a service
+sprite-env services create <name> \
+  --cmd <binary-path> \
+  --args "<arg1>,<arg2>" \
+  --http-port 8080
+
+# Only one service can own --http-port; it auto-starts on incoming HTTP requests.
+# --cmd takes the binary only — pass arguments via --args (comma-separated):
+#   WRONG:  --cmd "python3 -m http.server 8080"
+#   RIGHT:  --cmd python3 --args "-m,http.server,8080" --http-port 8080
+
+sprite-env services list
+sprite-env services start <name>
+sprite-env services stop <name>
+sprite-env services restart <name>   # Preferred over stop + start
+sprite-env services delete <name>
+sprite-env services --help           # Full option reference
+```
+
+### Service logs
+
+```sh
+ls /.sprite/logs/services/           # Log files per service
+cat /.sprite/logs/services/<name>    # Tail a specific service log
+```
+
+## Checkpoints
+
+Point-in-time snapshots of the writable filesystem overlay. Only overlay data is captured (copy-on-write).
+
+```sh
+sprite-env checkpoints create                          # Snapshot current state
+sprite-env checkpoints create --comment "description"  # With descriptive comment
+sprite-env checkpoints list
+```
+
+Checkpoints are fast — create one whenever the instance reaches a known-good state. The last 5 checkpoints are mounted at `/.sprite/checkpoints/v<N>/`.
+
+**Restore**: use the external `sprite restore <id>` command. Restore drops the entire current session — always confirm with the user before restoring.
+
+## Network Policy
+
+```sh
+cat /.sprite/policy/network.json     # Allowed egress domains
+```
+
+Respect the domain allowlist. Avoid raw IP addresses unless resolved from an allowed domain.
+
+## Context Files
+
+| Path | Contents |
+|------|----------|
+| `/.sprite/llm.txt` | Platform behavior: services, checkpoints, filesystem, network |
+| `/.sprite/docs/agent-context.md` | Full environment overview |
+| `/.sprite/docs/languages.md` | Language runtimes and version managers |
+| `/.sprite/languages/<lang>/llm.txt` | Per-language runtime details |
+| `/.sprite/logs/services/` | Service log files |
+| `/.sprite/checkpoints/v<N>/` | Last 5 checkpoint snapshots |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 | `review-pr` | `/review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
 | `create-commit` | `/commit` | Stage changes safely, generate a conventional-commit message, and block secrets from being committed |
 | `refine-prose` | `/refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
+| `manage-sprites` | `/manage-sprites` | Provision, operate, checkpoint, and destroy sprites.dev instances via the `sprite` CLI |
 
 ## Adding or Managing Skills
 


### PR DESCRIPTION
Closes #84

## Summary

- Adds `.agents/skills/manage-sprites/SKILL.md` with progressive-disclosure instructions covering the full sprites.dev lifecycle: authenticate, create, exec, checkpoint, restore, and destroy
- Adds `references/sprites-cli.md` — cheat sheet for the external `sprite` CLI (sourced from `sprite --help`)
- Adds `references/sprites-services.md` — reference for `sprite-env` internal service and checkpoint management (sourced from the `/.sprite/` audit)
- Updates `AGENTS.md` skill table with the new entry

## Test plan

- [ ] `SKILL.md` frontmatter: `name` = `manage-sprites`, description ≤ 1024 chars, required fields present
- [ ] Trigger test: "create a sprite", "run a command on my sprite", "checkpoint my sprite" activate the skill
- [ ] Core lifecycle: `sprite create test-x && sprite exec -s test-x echo hello && sprite destroy test-x`
- [ ] Checkpoint round-trip: snapshot → destroy → restore → confirm state intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)