### PR TITLE
docs(skills): remove redundant progressive disclosure tables

### DIFF
--- a/.agents/skills/create-commit/SKILL.md
+++ b/.agents/skills/create-commit/SKILL.md
@@ -114,10 +114,3 @@ existing issue in place rather than always creating a new one.
 fix: correct typo and broken link in AGENTS.md
 ```
 
-## Progressive Disclosure
-
-| Level | Content | When to load | Target size |
-|-------|---------|--------------|-------------|
-| 1 | `name` + `description` | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body (this file) | When skill is triggered | < 5,000 tokens |
-| 3 | `references/secret-patterns.md` | Step 2: secret detection | ~500 tokens |

--- a/.agents/skills/create-plan/SKILL.md
+++ b/.agents/skills/create-plan/SKILL.md
@@ -157,14 +157,6 @@ Fetches issue #35, generates an updated plan, edits the issue in place, and post
 ```
 Same as above; repo is extracted from the URL.
 
-## Progressive Disclosure
-
-| Level | Content | When to load | Target size |
-|-------|---------|--------------|-------------|
-| 1 | `name` + `description` | Always (startup) | ~100 tokens |
-| 2 | `SKILL.md` body (this file) | When skill is triggered | < 5,000 tokens |
-| 3 | None currently defined | — | — |
-
 **Generated issue body structure:**
 ```markdown
 ## Objective

--- a/.agents/skills/manage-skills/references/skill-format.md
+++ b/.agents/skills/manage-skills/references/skill-format.md
@@ -136,6 +136,8 @@ Prefer explicit over implicit.
 
 Keep `SKILL.md` lean. Move large examples, schemas, and reference docs into `references/` or `assets/` and instruct agents to read them on demand.
 
+**Do not** add a progressive disclosure table to individual `SKILL.md` files. The table above describes how the system works; copying it into each skill is redundant and should be removed when found.
+
 ## Worked Example
 
 Directory: `.agents/skills/extract-pdf-text/`


### PR DESCRIPTION
These tables restate how the skill loading system works and add no
skill-specific value. Added an explicit note to skill-format.md
discouraging their use in individual SKILL.md files.