### PR TITLE
fix(format-review-comments): add direct invocation steps, label guidance, and examples

### DIFF
--- a/.agents/skills/format-review-comments/SKILL.md
+++ b/.agents/skills/format-review-comments/SKILL.md
@@ -25,6 +25,16 @@ Apply this format **proactively** whenever you:
 
 Use this format whenever you are reviewing anything — no explicit request needed.
 
+## Steps
+
+When invoked directly to format existing comments:
+
+1. Identify the comments to format — from context, the user's message, or by asking if unclear.
+2. Read `references/conventional-comments-spec.md` to confirm label and decoration meanings.
+3. For each comment, choose the label that best matches the comment's intent (see Core labels and label-selection guidance below).
+4. Apply the format: `label [decorations]: subject` followed by an optional body on a new line.
+5. Output all reformatted comments in the same order as the originals.
+
 ## Format
 
 ```
@@ -43,6 +53,8 @@ label [decorations]: subject
 
 ## Core labels
 
+Read `references/conventional-comments-spec.md` before selecting labels for any comment that is not obviously a nitpick or praise.
+
 | Label | Intent |
 |-------|--------|
 | `praise` | Highlights something positive; never blocking |
@@ -55,7 +67,7 @@ label [decorations]: subject
 | `chore` | Simple housekeeping (rename, move, reformat); non-blocking |
 | `note` | Informational; no action required |
 
-For the full label and decoration reference, read `references/conventional-comments-spec.md`.
+When selecting a label for an existing comment, match the comment's intent to the label definitions in `references/conventional-comments-spec.md`. When intent is ambiguous, prefer `suggestion` over `issue` and `note` over `thought`.
 
 ## Quick examples
 
@@ -69,5 +81,26 @@ issue [blocking]: this will panic on nil input; add a nil check before dereferen
 question: why is this sorted descending? just want to make sure it's intentional
 
 nitpick: s/recieve/receive/
+```
+
+Example with body:
+
+```
+suggestion: extract the retry logic into a helper
+
+This block appears in three places. A shared helper would make it easier to adjust the backoff strategy in one place.
+```
+
+**Direct invocation — before and after:**
+
+Input:
+> This will crash on empty lists.
+> Also the variable name is confusing.
+
+Output:
+```
+issue [blocking]: this will crash on empty lists — add a guard before iterating
+
+nitpick: variable name is unclear — consider renaming to reflect its purpose
 ```
 


### PR DESCRIPTION
- add numbered Steps section for direct invocation procedure (blocking finding)
- add directive to read reference spec before selecting labels
- replace passive reference pointer with actionable label-selection guidance
- add body example and direct invocation before/after example to Quick examples

https://claude.ai/code/session_016vGUtrYgHGaGAwp4Hm2WtT