### PR TITLE
feat(audit-skills): add audit-skills skill

### DIFF
--- a/.agents/skills/audit-skills/SKILL.md
+++ b/.agents/skills/audit-skills/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: audit-skills
+description: >
+  Produces a complete health report on a skill library: per-skill structural
+  validation followed by cross-skill analysis covering trigger conflicts,
+  redundancy, workflow coverage gaps, and composition chains. Auto-fixes
+  unambiguous minor structural issues (whitespace, missing optional metadata)
+  and formats all other findings with format-review-comments.
+  TRIGGER when: user asks to audit skills, check skill coverage, validate all
+  skills, find gaps in skills, check for trigger conflicts, or health-check the
+  skill library.
+  DO NOT TRIGGER when: user asks to create, update, rename, or delete a skill
+  (use manage-skills instead); or to evaluate a single skill for quality
+  (use review-skill instead).
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Audit Skills
+
+Produces a two-pass health report on the entire skill library: structural validation per skill, then cross-skill analysis covering trigger conflicts, redundancy, workflow gaps, and composition chains. All findings are formatted with `format-review-comments`. Minor issues are auto-fixed silently; everything else is reported.
+
+## Instructions
+
+### Setup
+
+Read `references/checks.md` before beginning. It contains the authoritative check specifications, coverage map, and output format details referenced throughout these instructions.
+
+### Pass 1 — Structural Validation
+
+Run structural checks on every skill. Discover all skills with:
+
+```
+Glob: .agents/skills/*/SKILL.md
+```
+
+For each skill found, perform the checks listed in `references/checks.md` under **Structural Checks**. Checks fall into two categories:
+
+**Auto-fix silently** (do not report, apply the fix and move on):
+- Leading or trailing whitespace in frontmatter string values
+- Missing optional metadata fields (`license`, `metadata.author`, `metadata.version`)
+- Minor formatting inconsistencies in the SKILL.md body (list indentation, blank lines)
+
+**Report as findings** (everything else):
+- `name` field absent or empty
+- `description` field absent or empty
+- `name` value does not match the parent directory name exactly
+- `description` exceeds 1024 characters
+- `description` does not open with an action verb in third person
+- `description` does not include a "when to invoke" condition (`Use when`, `TRIGGER when`, or equivalent)
+- Skill scope overlaps with another skill but lacks `TRIGGER when` / `DO NOT TRIGGER when` disambiguation lines
+- Files in `scripts/`, `references/`, or `assets/` that are not referenced anywhere in `SKILL.md`
+
+If auto-fixes are applied, use the `create-commit` skill to stage and commit them before the final report. When fixes span multiple skills, use a single commit:
+
+```
+fix(<skill-name>): correct minor structural issues
+```
+
+(or `fix: correct minor structural issues across N skills` when fixes span multiple skills)
+
+If no auto-fixes are needed, skip the intermediate commit.
+
+### Pass 2 — Cross-Skill Analysis
+
+After structural validation, run the cross-skill checks listed in `references/checks.md` under **Cross-Skill Checks**. These require reading all SKILL.md files together:
+
+1. **Trigger conflicts** — Collect all natural-language trigger phrases from every skill's `description`. Flag any two skills that share the same phrase or where one phrase is a substring of another.
+
+2. **Redundancy** — Compare skill scopes. Flag pairs where the stated purpose substantially overlaps (merge candidates). Use the `description` fields as the primary signal.
+
+3. **Workflow coverage** — Map each skill to the workflow stages defined in `references/checks.md` (plan → implement → commit → review → release). Flag stages with no skill coverage.
+
+4. **Composition gaps** — Scan all `SKILL.md` bodies for references to other skills (e.g., "use the `foo` skill", "apply `bar`"). For each reference, verify that the named skill exists under `.agents/skills/`. Flag missing skills. Also identify two-step workflows referenced across multiple skills (e.g., implement → commit, commit → review) and check whether any skill explicitly coordinates both steps. If no coordinating skill exists and the chain appears in more than one skill's instructions, flag it as a `suggestion`.
+
+5. **Naming consistency** — Check that every skill name follows the action+object formula (verb+noun, e.g., `manage-skills`, `create-commit`). If the library has 10 or more skills, check whether related skills share a namespace prefix. Flag deviations.
+
+### Report Structure
+
+Present findings in this order, as specified in `references/checks.md` under **Report Format**:
+
+1. **Structural Findings** — one sub-section per skill with issues; skills that pass cleanly are omitted
+2. **Cross-Skill Findings** — one sub-section per check category; categories with no findings are omitted
+3. **Coverage Map** — rendered table showing workflow stages vs. skills (see `references/checks.md` for format)
+4. **Overall Summary** — counts: skills audited, auto-fixes applied, findings by severity
+
+Format every reported finding with the `format-review-comments` skill. Use severity labels: `issue [blocking]` for structural violations that will break agent behavior, `suggestion` for quality improvements, `nitpick` for style issues.
+
+Apply the `refine-prose` skill to the full report before presenting it. Do not announce this step.
+
+## Examples
+
+**Invocation:**
+```
+audit my skills
+```
+or
+```
+check skill coverage
+```
+or
+```
+validate all skills
+```
+
+**Sample coverage map table:**
+
+| Stage     | Skills                                   | Status   |
+|-----------|------------------------------------------|----------|
+| plan      | manage-plans                             | covered  |
+| implement | manage-skills, review-skill, audit-skills| covered  |
+| commit    | create-commit                            | covered  |
+| review    | review-pr, review-skill                  | covered  |
+| release   | —                                        | **gap**  |
+
+**Sample trigger-conflict finding:**
+
+```
+suggestion: manage-skills and audit-skills both trigger on "audit skills"
+
+Both skills list "audit skills" as a trigger phrase. Add DO NOT TRIGGER
+disambiguation to clarify that manage-skills handles structural audits as
+part of lifecycle management while audit-skills produces a full library
+health report.
+```
+
+**Sample structural finding:**
+
+```
+issue [blocking](review-skill): name field does not match directory
+
+The `name` frontmatter field reads "review_skill" but the directory is
+named "review-skill". Rename the frontmatter value to "review-skill".
+```

--- a/.agents/skills/audit-skills/references/checks.md
+++ b/.agents/skills/audit-skills/references/checks.md
@@ -1,0 +1,200 @@
+# Audit Checks Reference
+
+This file defines the authoritative check specifications for the `audit-skills` skill. It is organized into three sections: structural checks (Pass 1), cross-skill checks (Pass 2), and report format.
+
+---
+
+## Structural Checks (Pass 1)
+
+Run these checks on every skill discovered via `Glob: .agents/skills/*/SKILL.md`.
+
+### Required Field Checks
+
+| Check | Severity | Auto-fix? |
+|-------|----------|-----------|
+| `name` field is present in frontmatter | issue [blocking] | No |
+| `name` field is non-empty | issue [blocking] | No |
+| `name` value matches the parent directory name exactly | issue [blocking] | No |
+| `description` field is present in frontmatter | issue [blocking] | No |
+| `description` field is non-empty | issue [blocking] | No |
+
+### Description Quality Checks
+
+| Check | Severity | Auto-fix? |
+|-------|----------|-----------|
+| `description` is 1024 characters or fewer | issue [blocking] | No — report and ask user to shorten |
+| `description` opens with an action verb in third person (e.g., "Produces", "Manages", "Stages") | suggestion | No |
+| `description` includes a "when to invoke" condition (`Use when`, `TRIGGER when`, or equivalent phrase) | suggestion | No |
+| When skill scope overlaps with another skill, `description` includes `TRIGGER when` and `DO NOT TRIGGER when` disambiguation lines | suggestion | No |
+
+### File Reference Checks
+
+| Check | Severity | Auto-fix? |
+|-------|----------|-----------|
+| Every file under `scripts/` is referenced by name somewhere in `SKILL.md` | suggestion | No |
+| Every file under `references/` is referenced by name somewhere in `SKILL.md` | suggestion | No |
+| Every file under `assets/` is referenced by name somewhere in `SKILL.md` | suggestion | No |
+
+### Auto-Fix Rules
+
+Apply the following corrections silently without reporting them. Commit fixes together in one pass before generating the final report.
+
+- Strip leading and trailing whitespace from frontmatter string values
+- Add missing optional fields with sensible defaults:
+  - `license: Apache-2.0` if absent
+  - `metadata: {}` block if absent (do not guess `author` or `version`)
+- Normalize list indentation in SKILL.md body to 2-space indent
+- Remove duplicate blank lines in SKILL.md body (collapse 3+ consecutive blank lines to 2)
+
+---
+
+## Cross-Skill Checks (Pass 2)
+
+Run these checks after all skills have been read. They require comparing skills against each other.
+
+### Trigger Conflicts
+
+**Goal:** Identify trigger phrases that would cause an agent to ambiguously choose between two or more skills.
+
+**Method:**
+1. Extract all natural-language trigger phrases from each skill's `description` field. Phrases appear in `TRIGGER when:` lines, `Use when` clauses, and the parenthetical examples embedded in descriptions (e.g., *"also triggered by 'create a commit'"*).
+2. Normalize: lowercase, strip punctuation, collapse whitespace.
+3. Flag any two skills where one skill's normalized trigger phrase is an exact match or a substring of another skill's normalized trigger phrase.
+
+**Severity:** `suggestion` for partial overlaps; `issue [blocking]` for exact matches with no disambiguation.
+
+### Redundancy
+
+**Goal:** Identify skills with substantially overlapping scope that are candidates for merging.
+
+**Method:**
+1. Compare every pair of skill `description` fields.
+2. Flag pairs where the core action (what the skill does) is the same or where the `description` mentions the same domain without clear differentiation.
+3. Do not flag skills that are intentionally layered (e.g., `review-skill` reviews one skill; `audit-skills` reviews the library — related but not redundant).
+
+**Severity:** `suggestion`
+
+### Workflow Coverage
+
+**Goal:** Ensure the skill library collectively covers the full software development workflow.
+
+**Coverage Map:**
+
+| Stage | Description | Example skills |
+|-------|-------------|----------------|
+| plan | Breaking down work, defining requirements, creating issues | manage-plans |
+| implement | Writing code, creating/updating skills, making changes | manage-skills, audit-skills |
+| commit | Staging and committing changes safely | create-commit |
+| review | Evaluating PRs, skills, or prose quality | review-pr, review-skill, refine-prose |
+| release | Publishing, deploying, tagging versions | _(none — gap)_ |
+
+**Method:**
+1. For each skill, determine which stage(s) it primarily covers based on its `description`.
+2. Render the coverage map table with the actual skills found, replacing the "Example skills" column.
+3. Flag any stage with no covering skill as a gap.
+
+**Severity:** `suggestion` for gaps
+
+### Composition Gaps
+
+**Goal:** Verify that skills referenced by others exist, and that chained workflows have adequate coordination.
+
+**Method:**
+1. Scan every `SKILL.md` body for skill references — patterns like:
+   - `use the \`foo\` skill`
+   - `apply \`bar\``
+   - `invoke the \`baz\` skill`
+   - `run \`qux\``
+2. For each reference, check that `.agents/skills/<referenced-skill>/SKILL.md` exists. Flag missing skills as `bug`.
+3. Identify sequential skill chains (skill A's output is skill B's input) and check whether a coordinating skill exists. Flag missing glue as `suggestion`.
+
+**Severity:** `issue [blocking]` for missing referenced skills; `suggestion` for missing coordination
+
+### Naming Consistency
+
+**Goal:** Ensure all skill names follow the action+object formula and namespace rules.
+
+**Method:**
+1. Check each skill name: it should contain at least one hyphen and follow a verb+noun or verb+adjective+noun pattern (e.g., `manage-skills`, `create-commit`, `review-pr`).
+2. If the library contains 10 or more skills, check whether related skills share a consistent namespace prefix (e.g., `manage-skills`, `manage-plans`, `manage-sprites` share `manage-`). Flag related skills that lack a shared prefix.
+3. Flag names that are single words, noun-only, or do not include an action verb.
+
+**Severity:** `nitpick`
+
+---
+
+## Report Format
+
+Structure the final report in this order:
+
+### 1. Structural Findings
+
+One sub-section per skill with at least one reported finding. Format:
+
+```
+## Structural Findings
+
+### <skill-name>
+
+<finding formatted with format-review-comments>
+<finding formatted with format-review-comments>
+```
+
+Omit skills that pass all checks cleanly. If no skills have findings, write:
+
+```
+## Structural Findings
+
+All skills passed structural validation.
+```
+
+### 2. Cross-Skill Findings
+
+One sub-section per check category that has findings. Format:
+
+```
+## Cross-Skill Findings
+
+### Trigger Conflicts
+
+<finding formatted with format-review-comments>
+
+### Workflow Coverage
+
+<finding formatted with format-review-comments>
+```
+
+Omit categories with no findings. If no cross-skill issues are found, write:
+
+```
+## Cross-Skill Findings
+
+No cross-skill issues detected.
+```
+
+### 3. Coverage Map
+
+Always render the coverage map table, even if all stages are covered:
+
+```
+## Coverage Map
+
+| Stage     | Skills          | Status     |
+|-----------|-----------------|------------|
+| plan      | manage-plans    | covered    |
+| implement | manage-skills   | covered    |
+| commit    | create-commit   | covered    |
+| review    | review-pr       | covered    |
+| release   | —               | **gap**    |
+```
+
+### 4. Overall Summary
+
+```
+## Summary
+
+- Skills audited: N
+- Auto-fixes applied: N (committed separately)
+- Structural findings: N (X bug, Y suggestion, Z nitpick)
+- Cross-skill findings: N (X bug, Y suggestion, Z nitpick)
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 | `create-commit` | `/commit` | Stage changes safely, generate a conventional-commit message, and block secrets from being committed |
 | `refine-prose` | `/refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
 | `manage-sprites` | `/manage-sprites` | Provision, operate, checkpoint, and destroy sprites.dev instances via the `sprite` CLI |
+| `audit-skills` | `/audit-skills` | Produce a full health report on the skill library: structural validation per skill and cross-skill analysis covering trigger conflicts, redundancy, workflow gaps, and composition chains |
 
 ## Adding or Managing Skills
 


### PR DESCRIPTION
Two-pass health report for skill libraries: structural validation per
skill (with silent auto-fix for minor issues) followed by cross-skill
analysis covering trigger conflicts, redundancy, workflow coverage gaps,
and composition chains. All findings formatted with format-review-comments.
Closes #101