### PR TITLE
chore: rename repository from skills to hax-yax

### DIFF
--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -163,7 +163,7 @@ Fetches issue #35, generates an updated plan, edits the issue in place, and post
 
 **Invocation (by issue URL — update mode):**
 ```
-/upsert-plan https://github.com/geemus/skills/issues/35
+/upsert-plan https://github.com/geemus/hax-yax/issues/35
 ```
 Same as above; repo is extracted from the URL.
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "skills",
+  "name": "hax-yax",
   "description": "Reusable agent skills for Claude Code — commit safety, plan generation, PR review, prose refinement, and more.",
   "version": "1.0.0",
   "author": "geemus",
   "license": "MIT",
-  "repository": "https://github.com/geemus/skills",
+  "repository": "https://github.com/geemus/hax-yax",
   "keywords": ["claude", "skills", "agent", "agentskills", "productivity"],
   "skills": "./.agents/skills/"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Skills live under `.agents/skills/` so that agents running within this repositor
 
 ## Plugin Installation
 
-Skills are available under the `skills` namespace (e.g., `/skills:upsert-plan`) when installed via the Claude Code plugin, or directly (e.g., `/upsert-plan`) when running within this repository.
+Skills are available under the `hax-yax` namespace (e.g., `/hax-yax:upsert-plan`) when installed via the Claude Code plugin, or directly (e.g., `/upsert-plan`) when running within this repository.
 
 ## Skills Format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- Renamed repository from `geemus/skills` to `geemus/hax-yax`; updated plugin manifest name, repository URL, all `/skills:` namespace references to `/hax-yax:`, and example URLs across `README.md`, `AGENTS.md`, and `.agents/skills/upsert-plan/SKILL.md`
 - Renamed `manage-plans` → `upsert-plan`: "upsert" more precisely describes the create-or-update operation; singular noun matches single-item-per-invocation behavior
 - Renamed `manage-skills` → `upsert-skill`: same rationale — dominant operation is create-or-update a single skill
 - Renamed `manage-sprites` → `manage-sprite`: singular noun correction; "manage" retained because destroy and exec are equal-weight operations alongside create/update

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# skills
+# hax-yax
 
 Reusable agent skills for Claude Code and other AI coding agents. Follows the [agentskills.io](https://agentskills.io) open standard and ships a native [Claude Code plugin manifest](https://docs.claude.ai/code/plugins) for one-command installation.
 
@@ -6,12 +6,12 @@ Reusable agent skills for Claude Code and other AI coding agents. Follows the [a
 
 | Skill | Trigger | Purpose |
 |-------|---------|---------|
-| `upsert-skill` | `/skills:upsert-skill` | Create, update, manage, and audit skills in this repository |
-| `upsert-plan` | `/skills:upsert-plan` | Create and update structured work plans as GitHub issues |
+| `upsert-skill` | `/hax-yax:upsert-skill` | Create, update, manage, and audit skills in this repository |
+| `upsert-plan` | `/hax-yax:upsert-plan` | Create and update structured work plans as GitHub issues |
 | `format-review-comments` | applied proactively during code review | Format review and feedback comments using the Conventional Comments standard |
-| `review-pr` | `/skills:review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
-| `create-commit` | `/skills:commit` | Stage changes safely, generate a conventional-commit message, and block secrets from being committed |
-| `refine-prose` | `/skills:refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
+| `review-pr` | `/hax-yax:review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
+| `create-commit` | `/hax-yax:commit` | Stage changes safely, generate a conventional-commit message, and block secrets from being committed |
+| `refine-prose` | `/hax-yax:refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
 
 ## Installation
 
@@ -20,17 +20,17 @@ Reusable agent skills for Claude Code and other AI coding agents. Follows the [a
 Install from a local clone using `--plugin-dir`:
 
 ```sh
-git clone https://github.com/geemus/skills
-claude --plugin-dir ./skills
+git clone https://github.com/geemus/hax-yax
+claude --plugin-dir ./hax-yax
 ```
 
 Or install directly from the repository URL once Claude Code supports remote plugin installation:
 
 ```sh
-claude plugin install https://github.com/geemus/skills
+claude plugin install https://github.com/geemus/hax-yax
 ```
 
-Skills are registered under the `skills` namespace (e.g. `/skills:upsert-plan`). Run `/help` inside Claude Code to see all available commands.
+Skills are registered under the `hax-yax` namespace (e.g. `/hax-yax:upsert-plan`). Run `/help` inside Claude Code to see all available commands.
 
 ### Standalone Claude Code use
 
@@ -39,7 +39,7 @@ If you already have the repository checked out and want skills available without
 ```sh
 # From within the repository, skills load automatically.
 # From another project, symlink or copy the skills directory:
-ln -s /path/to/skills/.agents/skills .claude/skills
+ln -s /path/to/hax-yax/.agents/skills .claude/skills
 ```
 
 ## Repository structure
@@ -64,7 +64,7 @@ ln -s /path/to/skills/.agents/skills .claude/skills
 
 ## Contributing
 
-Skills follow the format defined in `.agents/skills/upsert-skill/references/skill-format.md`. Use the `upsert-skill` skill (`/skills:upsert-skill`) to create or update skills with guided steps and validation.
+Skills follow the format defined in `.agents/skills/upsert-skill/references/skill-format.md`. Use the `upsert-skill` skill (`/hax-yax:upsert-skill`) to create or update skills with guided steps and validation.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org): `<type>[scope]: <description>`.
 


### PR DESCRIPTION
## Summary

- `.claude-plugin/plugin.json`: `name` → `hax-yax`, `repository` URL updated
- `README.md`: title, clone/install URLs, all `/skills:` namespace refs → `/hax-yax:`
- `AGENTS.md`: namespace example → `/hax-yax:upsert-plan`
- `.agents/skills/upsert-plan/SKILL.md`: example issue URL → `geemus/hax-yax`
- `CHANGELOG.md`: rename entry added

## Test plan

- [ ] `grep -r "geemus/skills" . --exclude-dir=.git` returns no output (only CHANGELOG prose)
- [ ] `grep '"name"' .claude-plugin/plugin.json` reads `"hax-yax"`
- [ ] `head -1 README.md` reads `# hax-yax`
- [ ] `grep -r "/skills:" . --exclude-dir=.git` returns no output

https://claude.ai/code/session_0182HY2ZCMSLAHsVnJ1CTWQs