### PR TITLE
fix: change author to object in plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hax-yax",
   "description": "Reusable agent skills for Claude Code — commit safety, plan generation, PR review, prose refinement, and more.",
   "version": "1.0.0",
-  "author": "geemus",
+  "author": { "name": "geemus" },
   "license": "MIT",
   "repository": "https://github.com/geemus/hax-yax",
   "keywords": ["claude", "skills", "agent", "agentskills", "productivity"],


### PR DESCRIPTION
## Summary

- Change `author` field in `.claude-plugin/plugin.json` from a string to an object (`{ "name": "geemus" }`) to match the Claude Code plugin manifest schema

## Test plan

- [ ] Run `claude --plugin-dir /path/to/hax-yax` and verify no "invalid manifest" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)