### PR TITLE
feat(upsert-plan,review-pr): include agent guidance updates/checks

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.3"
+  version: "1.4"
 ---
 
 # Review PR
@@ -74,6 +74,13 @@ Work through every dimension in order. For each, read the relevant changed files
 - Are public APIs, exported functions, and non-obvious logic commented?
 - Is the PR description accurate and complete?
 - Do `README`, `CHANGELOG`, or other docs need updating?
+
+#### Agent guidance
+
+- Do changes affect repo structure, skills, tooling, or conventions documented in agent instruction files (AGENTS.md, CLAUDE.md)?
+- Were agent instruction files updated to reflect those changes?
+- Are new skills, tools, or conventions introduced without corresponding updates to agent guidance?
+- If the PR modifies AGENTS.md or CLAUDE.md directly, apply the `review-agents-md` skill to evaluate those changes.
 
 ### 4. Format all feedback with format-review-comments
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.0"
+  version: "2.1"
 ---
 
 # Upsert Plan
@@ -72,6 +72,8 @@ Annotate dependencies explicitly:
 ```
 
 Mark tasks that can run in parallel with a note: _(parallel with: Task X)_.
+
+**Agent guidance**: If the work touches repo structure, skills, tooling, or conventions documented in agent instruction files (AGENTS.md, CLAUDE.md), include a final task to run `upsert-agents-md` to keep those files current.
 
 **Update mode**: preserve the checked/unchecked state of any task checkboxes that appear in the existing issue. Do not uncheck tasks that were already checked.
 


### PR DESCRIPTION
- upsert-plan: add agent guidance note to Tasks section — when work
  touches repo structure, skills, tooling, or conventions, include a
  final task to run upsert-agents-md
- review-pr: add Agent guidance dimension to step 3 — check whether
  AGENTS.md/CLAUDE.md need updating and apply review-agents-md when
  those files are directly modified

Closes #123