### PR TITLE
docs: add worktree awareness section to AGENTS.md

### DIFF
--- a/.agents/skills/review-agents-md/SKILL.md
+++ b/.agents/skills/review-agents-md/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Review AGENTS.md
@@ -29,9 +29,9 @@ If the user provides a file path or filename as an argument (e.g., `/review-agen
 
 Otherwise, search the repository for agent instruction files. Look for any of the following:
 
-- `AGENTS.md` (repo root)
-- `CLAUDE.md` (repo root or `.claude/CLAUDE.md`)
-- `CURSOR.md` (repo root)
+- `AGENTS.md` (worktree root)
+- `CLAUDE.md` (worktree root or `.claude/CLAUDE.md`)
+- `CURSOR.md` (worktree root)
 - `.github/copilot-instructions.md`
 - `.cursorrules`
 
@@ -111,7 +111,7 @@ Apply the `refine-prose` skill to all output before presenting it. Do not announ
 ```
 /review-agents-md
 ```
-Finds `AGENTS.md` in the repo root and proceeds automatically.
+Finds `AGENTS.md` in the worktree root and proceeds automatically.
 
 **Sample output — no agent instruction file found:**
 ```

--- a/.agents/skills/upsert-agents-md/SKILL.md
+++ b/.agents/skills/upsert-agents-md/SKILL.md
@@ -12,7 +12,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Upsert AGENTS.md
@@ -27,9 +27,9 @@ Creates or updates agent instruction files by surveying the actual repository an
 
 **Target file** — if the user provides a filename argument (e.g. `/upsert-agents-md CLAUDE.md`), use that path. Otherwise, search the repository for existing agent instruction files:
 
-- `AGENTS.md` (repo root)
-- `CLAUDE.md` (repo root or `.claude/CLAUDE.md`)
-- `CURSOR.md` (repo root)
+- `AGENTS.md` (worktree root)
+- `CLAUDE.md` (worktree root or `.claude/CLAUDE.md`)
+- `CURSOR.md` (worktree root)
 - `.github/copilot-instructions.md`
 - `.cursorrules`
 
@@ -37,7 +37,7 @@ Use `Glob` to locate all matches.
 
 - **Exactly one file found:** use it as the target (update mode).
 - **Multiple files found:** list each path and ask the user which to update.
-- **No files found:** default to `AGENTS.md` at the repo root (create mode).
+- **No files found:** default to `AGENTS.md` at the worktree root (create mode).
 
 In **update mode**, read the full contents of the existing file before continuing. Note any intentional customizations (non-standard sections, hand-written prose) to preserve them.
 
@@ -152,4 +152,4 @@ Reads the existing `CLAUDE.md`, surveys the repo for changes, produces an update
 ```
 /upsert-agents-md
 ```
-Finds `AGENTS.md` in the repo root, enters update mode automatically.
+Finds `AGENTS.md` in the worktree root, enters update mode automatically.

--- a/.agents/skills/upsert-skill/SKILL.md
+++ b/.agents/skills/upsert-skill/SKILL.md
@@ -12,7 +12,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.6"
+  version: "1.7"
 ---
 
 # Upsert Skill
@@ -33,10 +33,11 @@ Manages the lifecycle of reusable skills stored under `.agents/skills/`.
 4. Document natural-language trigger phrases in the `description` — include the phrases users are likely to say (e.g. *"create a commit"*, *"review this PR"*, *"make a plan"*). Use the inline `Use when...` form for simple skills; add explicit `TRIGGER when:` / `DO NOT TRIGGER when:` lines when the skill overlaps with others and disambiguation is needed. See the Natural Language Triggers section in `references/skill-format.md` for both patterns and concrete examples.
 5. Omit `allowed-tools` unless the user explicitly requests tool restrictions
 6. Write a clear Markdown body with instructions agents can follow directly
-7. Add `scripts/`, `references/`, or `assets/` subdirectories only for content too large to inline in `SKILL.md` (large examples, schemas, scripts, reference docs). See `references/skill-format.md` for the full progressive disclosure model.
-8. Apply the `refine-prose` skill to the `description` frontmatter field and the `SKILL.md` body — run it silently before saving
-9. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
-10. Commit: `feat(<skill-name>): add <skill-name> skill — <one-line summary>`
+7. Verify plugin self-containment — re-read the instructions imagining no access to this repository's `AGENTS.md`. Any guidance the skill needs must be in the `SKILL.md` itself or in a `references/` file shipped with the skill.
+8. Add `scripts/`, `references/`, or `assets/` subdirectories only for content too large to inline in `SKILL.md` (large examples, schemas, scripts, reference docs). See `references/skill-format.md` for the full progressive disclosure model.
+9. Apply the `refine-prose` skill to the `description` frontmatter field and the `SKILL.md` body — run it silently before saving
+10. Review `AGENTS.md` — update if the new skill affects documented structure, conventions, or workflow
+11. Commit: `feat(<skill-name>): add <skill-name> skill — <one-line summary>`
 
 ### Updating a skill
 

--- a/.agents/skills/upsert-skill/references/skill-format.md
+++ b/.agents/skills/upsert-skill/references/skill-format.md
@@ -183,6 +183,7 @@ For full API details, read `references/pdfminer-api.md`.
 - Never commit secrets, tokens, or credentials inside a skill
 - Skills that call external services must document required environment variables in `SKILL.md`
 - Skills performing destructive operations must include an explicit confirmation step
+- **Plugin self-containment**: each `SKILL.md` must be independently usable when the skill is installed as a plugin in another repository — do not rely on this repository's `AGENTS.md` or any other repo-level guidance being available to the agent
 
 ### Anti-patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,15 @@ To create, update, or delete skills with guided steps and correct conventions, u
     - `chore: update AGENTS.md structure`
 - Do not force-push to `main`
 
+## Worktree Awareness
+
+When running inside a git worktree (secondary working tree), scope all file operations to the current worktree root.
+
+- **Resolve the root** with `git rev-parse --show-toplevel`; never navigate above it
+- **"Repo root"** in any skill instruction means the current worktree root, not the main working tree
+- **Detect secondary worktrees** with `git worktree list`; if `$PWD` does not match the first entry's path, you are in a secondary worktree and must stay within it
+- **Changes committed** in a secondary worktree are isolated to that worktree's branch — do not stage or commit files from outside it
+
 ## Code Style & Conventions
 
 - Markdown: ATX headings (`#`), fenced code blocks with language tags


### PR DESCRIPTION
Clarifies that agents running in a secondary worktree must scope all
file operations to the current worktree root (git rev-parse --show-toplevel)
and that "repo root" in skill instructions refers to the worktree root,
not the main working tree.