### PR TITLE
feat(review-plan): add review-plan skill and wire into upsert-plan

### DIFF
--- a/.agents/skills/implement-plan/SKILL.md
+++ b/.agents/skills/implement-plan/SKILL.md
@@ -75,11 +75,7 @@ Invoke the `review-pr` skill on the current branch against the base branch (defa
 /review-pr <current-branch>
 ```
 
-Process the review findings:
-- **Blocking findings** (`issue [blocking]`): fix each one immediately, then re-run `create-commit` to commit the fixes before proceeding.
-- **Non-blocking findings** (`suggestion`, `nitpick`, `question`, `todo`, `note`): surface them to the user and ask: "These non-blocking findings were identified. Would you like me to address any of them before opening the PR?"
-
-Do not proceed to step 6 until all blocking findings are resolved.
+`review-pr` will automatically fix all actionable findings and commit them. Do not proceed to step 6 until `review-pr` completes.
 
 ### 6. Open a PR linked to the plan issue
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -81,9 +81,7 @@ Work through every dimension in order. Note findings for each. Only skip a dimen
 - Is the Background section grounded in what exists today, not just what will be built?
 - Are agent-instruction files (AGENTS.md, CLAUDE.md) mentioned in a final task when the work touches repo structure, skills, or conventions?
 
-### 3. Format all findings with format-review-comments (interactive mode only)
-
-If invoked silently (called from `upsert-plan`), skip this step and proceed directly to step 4.
+### 3. Format all findings with format-review-comments
 
 When presenting multiple findings, prefix each with a letter (a., b., c., …) so individual items can be referenced by letter.
 
@@ -98,16 +96,7 @@ Apply the `format-review-comments` skill to every comment. Do not write `praise`
 | Small unambiguous fix | `todo` |
 | Informational only | `note` |
 
-### 4. Apply findings silently (when called from upsert-plan)
-
-When invoked as a silent step within `upsert-plan`:
-- Do not output findings to the user
-- **Blocking findings** (`issue [blocking]`): apply the fix directly to the in-context plan draft
-- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): apply if the fix is unambiguous; skip otherwise
-- **Questions** (`question`): skip — do not interrupt the upsert-plan flow
-- After applying all fixes, return the revised plan draft and continue the upsert-plan workflow
-
-### 5. Write a review summary (interactive mode only)
+### 4. Write a review summary
 
 After per-comment feedback, write a brief summary (3–7 sentences) covering:
 
@@ -118,7 +107,7 @@ After per-comment feedback, write a brief summary (3–7 sentences) covering:
 
 Format the summary as a `note` conventional comment.
 
-### 6. Refine prose (interactive mode only)
+### 5. Refine prose
 
 Apply the `refine-prose` skill to all prose output — comments and the summary — before presenting. Do not apply it to code blocks, commands, or inline fix suggestions. Do not announce this step.
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -81,7 +81,9 @@ Work through every dimension in order. Note findings for each. Only skip a dimen
 - Is the Background section grounded in what exists today, not just what will be built?
 - Are agent-instruction files (AGENTS.md, CLAUDE.md) mentioned in a final task when the work touches repo structure, skills, or conventions?
 
-### 3. Format all findings with format-review-comments
+### 3. Format all findings with format-review-comments (interactive mode only)
+
+If invoked silently (called from `upsert-plan`), skip this step and proceed directly to step 4.
 
 When presenting multiple findings, prefix each with a letter (a., b., c., …) so individual items can be referenced by letter.
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: review-plan
+description: >
+  Evaluates structured work plans across six quality dimensions — objective
+  clarity, task actionability, dependency correctness, acceptance criteria
+  completeness, scope appropriateness, and structural completeness. Formats
+  all findings with format-review-comments. Use when the user asks to review,
+  audit, or evaluate a work plan.
+  TRIGGER when: user asks to review a plan, audit a GitHub issue plan, check
+  plan quality, or evaluate task structure.
+  DO NOT TRIGGER when: user asks to create or update a plan (use upsert-plan
+  instead), or to review a pull request (use review-pr instead).
+license: Apache-2.0
+metadata:
+  author: geemus
+  version: "1.0"
+---
+
+# Review Plan
+
+Evaluates a structured work plan across six quality dimensions and formats every finding using the `format-review-comments` skill.
+
+## Instructions
+
+### 1. Identify the plan
+
+Accept the plan as:
+- A GitHub issue number (e.g. `#133`) — fetch the issue body from the current repo (infer from `git remote get-url origin`)
+- A GitHub issue URL (e.g. `https://github.com/owner/repo/issues/133`) — fetch the issue body directly
+- An in-context draft — use the plan text already present in the conversation
+
+If no plan is specified and none is in context, ask: "Which plan would you like me to review? Provide an issue number, URL, or paste the plan text."
+
+Fetch or extract the full plan body before proceeding.
+
+### 2. Review each dimension
+
+Work through every dimension in order. Note findings for each. Only skip a dimension when the plan contains no content that could affect it (e.g. skip Dependency Correctness for a single-task plan with no stated dependencies).
+
+#### Objective clarity
+
+- Is the goal stated in one or two sentences?
+- Is it clear *why* the work matters, not just *what* will be done?
+- Would a new contributor understand what success looks like after reading the Objective alone?
+- Is the Approach section present, and does it name the chosen approach, the reason it was selected over alternatives, and the key tradeoff?
+
+#### Task actionability
+
+- Does each task have a single, clear deliverable?
+- Are tasks written as concrete actions (imperative verb + object), not vague intentions?
+- Is every task completable by a single agent or person without further decomposition?
+- Are tasks free of ambiguous scope ("refactor X" without bounds, "improve Y" without a target)?
+
+#### Dependency correctness
+
+- Are task dependencies annotated explicitly (e.g. `_(depends on: Task A)_`)?
+- Do stated dependencies match the logical ordering of the work?
+- Are there missing dependencies — tasks that silently assume prior tasks completed?
+- Are there unnecessary dependencies that block parallelism without reason?
+- Are tasks that can run in parallel marked with `_(parallel with: Task X)_`?
+
+#### Acceptance criteria completeness
+
+- Does every task or phase have at least one acceptance criterion?
+- Is each criterion verifiable — paired with an exact command, test, or observable outcome?
+- Does the set of criteria fully cover the Objective? Are any outcomes implied by the Objective missing?
+- Are criteria written as pass/fail conditions, not aspirations?
+
+#### Scope appropriateness
+
+- Is the plan free of tasks that are nice-to-have but not required by the acceptance criteria? (These belong in Future Work.)
+- Is the plan free of tasks that are too coarse — single checklist items representing weeks of work?
+- Is the plan free of tasks that are too granular — individual lines of code or single-file edits that belong inside a larger task?
+- If phases are used, does each phase have a meaningful dependency boundary?
+- Is anything in the plan better deferred to a follow-up issue?
+
+#### Structural completeness
+
+- Are all required sections present: Objective, Background, Approach, Tasks, Acceptance Criteria?
+- Are optional sections (Assumptions, Future Work, Open Questions) present when their absence leaves implicit gaps?
+- Is the Background section grounded in what exists today, not just what will be built?
+- Are agent-instruction files (AGENTS.md, CLAUDE.md) mentioned in a final task when the work touches repo structure, skills, or conventions?
+
+### 3. Format all findings with format-review-comments
+
+When presenting multiple findings, prefix each with a letter (a., b., c., …) so individual items can be referenced by letter.
+
+Apply the `format-review-comments` skill to every comment. Do not write `praise` comments — omit positive findings entirely. Choose the label that matches the severity and intent:
+
+| Situation | Recommended label |
+|-----------|------------------|
+| Blocks reliable execution | `issue [blocking]` |
+| Strong improvement | `suggestion` |
+| Minor wording or style | `nitpick` |
+| Needs clarification | `question` |
+| Small unambiguous fix | `todo` |
+| Informational only | `note` |
+
+### 4. Apply findings silently (when called from upsert-plan)
+
+When invoked as a silent step within `upsert-plan`:
+- Do not output findings to the user
+- For each `issue [blocking]` or `suggestion` finding, apply the fix directly to the in-context plan draft
+- For `nitpick` and `todo` findings, apply them if the fix is unambiguous; skip otherwise
+- For `question` findings, skip — do not interrupt the upsert-plan flow
+- After applying all fixes, return the revised plan draft and continue the upsert-plan workflow
+
+### 5. Write a review summary (interactive mode only)
+
+After per-comment feedback, write a brief summary (3–7 sentences) covering:
+
+- Overall assessment — ready to execute, needs minor improvements, or needs significant rework
+- The most important finding (name any blocking issues)
+- Any patterns visible across the plan
+- Any skipped dimensions and why
+
+Format the summary as a `note` conventional comment.
+
+### 6. Refine prose (interactive mode only)
+
+Apply the `refine-prose` skill to all prose output — comments and the summary — before presenting. Do not apply it to code blocks, commands, or inline fix suggestions. Do not announce this step.
+
+## Examples
+
+**Invocation by issue number:**
+```
+/review-plan #133
+```
+
+**Invocation by URL:**
+```
+/review-plan https://github.com/owner/repo/issues/133
+```
+
+**Invocation with in-context draft:**
+```
+/review-plan
+```
+The agent uses the plan text already present in the conversation.
+
+**Sample output — task actionability finding:**
+```
+issue [blocking]: "Improve the API layer" is not actionable — it has no bounded deliverable, so an agent cannot determine when the task is complete
+
+Rewrite as a concrete task:
+- [ ] Add rate-limit middleware to all `/api/v1` routes returning HTTP 429 on threshold breach
+```
+
+**Sample output — acceptance criteria finding:**
+```
+suggestion: Task C ("Update documentation") has no acceptance criterion — there is no way to verify it is done
+
+Add a verifiable criterion:
+- AGENTS.md skill table includes the new skill: `grep "skill-name" AGENTS.md`
+```
+
+**Sample output — dependency finding:**
+```
+todo: Task D depends on Task B and Task C per the implementation logic, but the annotation is missing
+
+Add:
+- [ ] Task D _(depends on: Task B, Task C)_
+```
+
+**Sample output — summary:**
+```
+note: overall this plan needs minor improvements before it is executable. One blocking issue: Task C lacks a bounded deliverable. Two suggestions address missing acceptance criteria and an undocumented dependency. Structural completeness and objective clarity are strong. Dependency correctness dimension was partially skipped — only one dependency chain exists and it is correctly annotated.
+```

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -107,7 +107,15 @@ After per-comment feedback, write a brief summary (3–7 sentences) covering:
 
 Format the summary as a `note` conventional comment.
 
-### 5. Refine prose
+### 5. Process findings
+
+After presenting findings and the summary:
+
+- **Actionable findings** (`issue [blocking]`, `suggestion`, `nitpick`, `todo`): apply each fix directly to the plan (edit the issue body or in-context draft as appropriate).
+- **Notes** (`note`): surface to the user as informational; no action required.
+- **Questions** (`question`): ask the user for clarification before proceeding.
+
+### 6. Refine prose
 
 Apply the `refine-prose` skill to all prose output — comments and the summary — before presenting. Do not apply it to code blocks, commands, or inline fix suggestions. Do not announce this step.
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -102,9 +102,9 @@ Apply the `format-review-comments` skill to every comment. Do not write `praise`
 
 When invoked as a silent step within `upsert-plan`:
 - Do not output findings to the user
-- For each `issue [blocking]` or `suggestion` finding, apply the fix directly to the in-context plan draft
-- For `nitpick` and `todo` findings, apply them if the fix is unambiguous; skip otherwise
-- For `question` findings, skip — do not interrupt the upsert-plan flow
+- **Blocking findings** (`issue [blocking]`): apply the fix directly to the in-context plan draft
+- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): apply if the fix is unambiguous; skip otherwise
+- **Questions** (`question`): skip — do not interrupt the upsert-plan flow
 - After applying all fixes, return the revised plan draft and continue the upsert-plan workflow
 
 ### 5. Write a review summary (interactive mode only)

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -118,8 +118,8 @@ Format the summary as a `note` conventional comment.
 
 After presenting findings and the summary:
 
-- **Blocking findings** (`issue [blocking]`): fix each one immediately using the available tools, then invoke the `create-commit` skill to commit the fixes. Do not proceed until all blocking findings are resolved.
-- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): surface them to the user and ask: "These non-blocking findings were identified. Would you like me to address any of them?"
+- **Actionable findings** (`issue [blocking]`, `suggestion`, `nitpick`, `todo`): fix each one immediately using the available tools, then invoke the `create-commit` skill to commit all fixes together. Do not proceed until all actionable findings are resolved.
+- **Notes** (`note`): surface to the user as informational; no action required.
 - **Questions** (`question`): ask the user for clarification before proceeding.
 
 ### 7. Refine prose

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "1.4"
+  version: "1.5"
 ---
 
 # Review PR
@@ -114,7 +114,15 @@ After the per-comment feedback, write a brief summary (3–7 sentences) covering
 
 Format the summary as a `note` conventional comment.
 
-### 6. Refine prose
+### 6. Process findings
+
+After presenting findings and the summary:
+
+- **Blocking findings** (`issue [blocking]`): fix each one immediately using the available tools, then invoke the `create-commit` skill to commit the fixes. Do not proceed until all blocking findings are resolved.
+- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): surface them to the user and ask: "These non-blocking findings were identified. Would you like me to address any of them?"
+- **Questions** (`question`): ask the user for clarification before proceeding.
+
+### 7. Refine prose
 
 Apply the `refine-prose` skill to the review summary and all comments before posting. Run it silently — do not announce the refinement step.
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -117,9 +117,8 @@ Do not remove tasks that self-review identified as missing or necessary.
 
 Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step to the user. Process the findings before proceeding:
 
-- **Blocking findings** (`issue [blocking]`): apply the fix directly to the draft
-- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): apply if the fix is unambiguous; skip otherwise
-- **Questions** (`question`): skip — do not interrupt the upsert-plan flow
+- **Actionable findings** (`issue [blocking]`, `suggestion`, `nitpick`, `todo`): apply the fix directly to the draft
+- **Non-actionable** (`note`, `question`): skip — do not interrupt the upsert-plan flow
 
 Carry the revised draft forward.
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -115,7 +115,7 @@ Do not remove tasks that self-review identified as missing or necessary.
 
 ### 7. Review plan
 
-Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step to the user. `review-plan` will handle findings automatically. Carry the revised draft forward.
+Invoke the `review-plan` skill on the current plan draft. `review-plan` will automatically fix all actionable findings. Do not proceed to step 8 until `review-plan` completes.
 
 ### 8. Refine prose
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: geemus
-  version: "2.2"
+  version: "2.3"
 ---
 
 # Upsert Plan
@@ -113,15 +113,19 @@ After self-review, challenge the scope. Ask: is there a simpler way to achieve t
 
 Do not remove tasks that self-review identified as missing or necessary.
 
-### 7. Refine prose
+### 7. Review plan
+
+Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step or surface findings to the user. Apply all `issue [blocking]` and `suggestion` findings directly to the draft; apply unambiguous `nitpick` and `todo` findings; skip `question` findings. Carry the revised draft forward.
+
+### 8. Refine prose
 
 Invoke the `refine-prose` skill (`/refine-prose`) on the full plan draft. Run it silently and carry the refined text forward — do not present the pre-refinement draft.
 
-### 8. Present the plan
+### 9. Present the plan
 
 State whether you are in **create mode** (a new issue will be created) or **update mode** (issue #N will be updated in place). Present the finished plan to the user and ask for confirmation before proceeding.
 
-### 9. Create or update the GitHub issue
+### 10. Create or update the GitHub issue
 
 Derive the issue title from the Objective: use a concise phrase (under 72 characters) that captures the core action and subject (e.g. "Add rate limiting to the public API").
 
@@ -147,7 +151,7 @@ gh issue create --title "..." --body-file .tmp/upsert-plan-body.md
 
 > **Side effect**: creating sub-issues also modifies the parent issue body to add `Sub-issue: #<number>` reference lines.
 
-### 10. Report back
+### 11. Report back
 
 Share the issue URL, state the number of tasks and phases, and call out any open questions or high-risk assumptions that should be resolved early. In update mode, confirm that the change-summary comment was posted.
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -115,12 +115,7 @@ Do not remove tasks that self-review identified as missing or necessary.
 
 ### 7. Review plan
 
-Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step to the user. Process the findings before proceeding:
-
-- **Actionable findings** (`issue [blocking]`, `suggestion`, `nitpick`, `todo`): apply the fix directly to the draft
-- **Non-actionable** (`note`, `question`): skip — do not interrupt the upsert-plan flow
-
-Carry the revised draft forward.
+Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step to the user. `review-plan` will handle findings automatically. Carry the revised draft forward.
 
 ### 8. Refine prose
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -115,7 +115,13 @@ Do not remove tasks that self-review identified as missing or necessary.
 
 ### 7. Review plan
 
-Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step or surface findings to the user. Apply all `issue [blocking]` and `suggestion` findings directly to the draft; apply unambiguous `nitpick` and `todo` findings; skip `question` findings. Carry the revised draft forward.
+Invoke the `review-plan` skill on the current plan draft. Run it silently — do not announce this step to the user. Process the findings before proceeding:
+
+- **Blocking findings** (`issue [blocking]`): apply the fix directly to the draft
+- **Non-blocking findings** (`suggestion`, `nitpick`, `todo`, `note`): apply if the fix is unambiguous; skip otherwise
+- **Questions** (`question`): skip — do not interrupt the upsert-plan flow
+
+Carry the revised draft forward.
 
 ### 8. Refine prose
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
       "Bash(git add:*)",
       "Bash(git checkout:*)",
       "Bash(git commit:*)",
-      "Bash(git remote:*)",
+      "Bash(git remote:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 | `manage-sprite-env` | `/manage-sprite-env` | Manage services, checkpoints, and environment info from within a running sprite instance |
 | `refine-prose` | `/refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
 | `review-agents-md` | `/review-agents-md` | Audit AGENTS.md and equivalent agent instruction files for completeness, accuracy, agent-friendliness, freshness, and scope coherence |
+| `review-plan` | `/review-plan` | Evaluate a structured work plan across six quality dimensions: objective clarity, task actionability, dependency correctness, acceptance criteria completeness, scope appropriateness, and structural completeness |
 | `review-pr` | `/review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
 | `review-skill` | `/review-skill` | Evaluate a skill for effectiveness across instruction clarity, trigger discoverability, example completeness, composability, and scope coherence |
 | `upsert-agents-md` | `/upsert-agents-md` | Create or update AGENTS.md and equivalent agent instruction files by surveying the repository |


### PR DESCRIPTION
Adds a new review-plan skill that evaluates structured work plans across
six quality dimensions (objective clarity, task actionability, dependency
correctness, acceptance criteria completeness, scope appropriateness,
structural completeness) and formats findings with format-review-comments.

Wires review-plan into upsert-plan as a silent step 7 between simplify
and refine-prose. Updates AGENTS.md skill table to include the new skill.

Closes #133