### PR TITLE
refactor: remove tmp dir pattern for long github content

### DIFF
--- a/.agents/skills/create-commit/SKILL.md
+++ b/.agents/skills/create-commit/SKILL.md
@@ -88,11 +88,7 @@ Derive the message following [Conventional Commits](https://www.conventionalcomm
 
 ### 5. Commit
 
-Display the proposed commit message to the user, then use the Write tool to write the message to `.tmp/create-commit.txt` and commit with:
-
-```bash
-git commit -F .tmp/create-commit.txt
-```
+Display the proposed commit message to the user, then commit.
 
 ## Examples
 

--- a/.agents/skills/upsert-plan/SKILL.md
+++ b/.agents/skills/upsert-plan/SKILL.md
@@ -129,14 +129,10 @@ State whether you are in **create mode** (a new issue will be created) or **upda
 
 Derive the issue title from the Objective: use a concise phrase (under 72 characters) that captures the core action and subject (e.g. "Add rate limiting to the public API").
 
-**Create mode:** Create a new GitHub issue with the derived title and plan body. Use the Write tool to write the body to `.tmp/upsert-plan-body.md`, then pass it via `--body-file`:
-
-```sh
-gh issue create --title "..." --body-file .tmp/upsert-plan-body.md
-```
+**Create mode:** Create a new GitHub issue with the derived title and plan body.
 
 **Update mode:**
-1. Update the issue title and body with the new plan. Use the Write tool to write the body to `.tmp/upsert-plan-body.md`, then pass it via `gh issue edit --body-file .tmp/upsert-plan-body.md`.
+1. Update the issue title and body with the new plan.
 2. Compose a change-summary comment covering only sections that changed. Format each changed section as a conventional comment in a lettered list:
 
    ```
@@ -147,7 +143,7 @@ gh issue create --title "..." --body-file .tmp/upsert-plan-body.md
 
    Use `added`, `revised`, or `removed` as the label; write the subject as `<Section name> — <one-sentence description of what changed and why>`. Post it as a comment on the issue.
 
-**Sub-issues**: If sub-issue tracking was agreed in step 1, create a child issue for each phase using the same method above, writing each body to `.tmp/upsert-plan-subissue.md` immediately before the `gh issue create` call that consumes it. Link each child to the parent by adding a line to the parent issue body: `- Sub-issue: #<number> — <phase name>`.
+**Sub-issues**: If sub-issue tracking was agreed in step 1, create a child issue for each phase. Link each child to the parent by adding a line to the parent issue body: `- Sub-issue: #<number> — <phase name>`.
 
 > **Side effect**: creating sub-issues also modifies the parent issue body to add `Sub-issue: #<number>` reference lines.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .claude/worktrees/
-.tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,6 @@ When running inside a git worktree (secondary working tree), scope all file oper
 - One skill per directory; do not bundle unrelated tasks
 - Prefer explicit over implicit; agents should not need to infer intent
 - Scripts should be self-contained or clearly document their dependencies
-- **Long content to CLI commands**: use the Write tool to write content to a skill-scoped path under `.tmp/` (e.g., `.tmp/upsert-plan-body.md`, `.tmp/create-commit.txt`), then pass via `--body-file` or `-F`. Do not use shell here-docs or HEREDOC patterns — use the Write tool instead. Repos using these skills must add `.tmp/` to their `.gitignore`.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Removes the `.tmp/` write-then-pass convention from `AGENTS.md`, `upsert-plan/SKILL.md`, and `create-commit/SKILL.md`
- Removes `.tmp/` from `.gitignore`
- Leaves method choice (heredoc, `-m`, etc.) to the agent

## Test plan

- [ ] Verify `upsert-plan` creates/updates issues without any `.tmp/` references
- [ ] Verify `create-commit` commits without writing `.tmp/create-commit.txt`