### PR TITLE
feat(review-agents-md): add leanness dimension to review checklist

### DIFF
--- a/.agents/skills/review-agents-md/SKILL.md
+++ b/.agents/skills/review-agents-md/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 
 # Review AGENTS.md
 
-Audits agent instruction files for completeness, accuracy, and agent-friendliness across five dimensions, with cross-referencing checks to verify that paths, scripts, and branch names mentioned in the file actually exist in the repository.
+Audits agent instruction files for completeness, accuracy, and agent-friendliness across six dimensions, with cross-referencing checks to verify that paths, scripts, and branch names mentioned in the file actually exist in the repository.
 
 ## Instructions
 
@@ -49,7 +49,7 @@ Read the full contents of the chosen file before reviewing. Do not begin reviewi
 
 Read `assets/review-checklist.md` before starting. Work through every dimension in order, applying each checklist item and noting findings as you go. Record whether an inline fix is clear and unambiguous for each finding.
 
-The five dimensions are:
+The six dimensions are:
 
 #### Completeness
 
@@ -70,6 +70,16 @@ Does the documented state match the actual repository? Flag stale references (do
 #### Scope coherence
 
 Is the file focused on agent guidance, or does it duplicate README/CHANGELOG content or serve a mixed audience? Flag content that actively misleads an agent as `issue [blocking]`; content that belongs elsewhere as `suggestion`.
+
+#### Leanness
+
+Does the file avoid duplicating information already present in code-level documentation (`@moduledoc`, docstrings, header comments, doc comments)? For each section that describes a specific module, type, callback, struct, byte-level layout, or symbol table, locate the corresponding code and compare wording. Apply the heuristic: *if a future agent could find this information by reading the relevant module, it should not also appear in full here — replace with a pointer*.
+
+Distinguish severities by intent:
+
+- **`suggestion`** — *pointer preferred*: section could collapse to a one-line pointer to the authoritative source, but the full prose is defensible
+- **`issue`** — *verbatim duplicate*: section repeats module docs verbatim or near-verbatim, creating two places to maintain
+- **`issue [blocking]`** — *bloat impairs usability* (rare): accumulated duplication has grown the file to the point that an agent struggles to locate actionable guidance
 
 ### 4. Format all findings with format-review-comments
 
@@ -158,6 +168,22 @@ Replace with an explicit rule:
 issue: the Skills table lists `create-plan` but `.agents/skills/create-plan/` does not exist in the repository — this entry is stale
 
 Remove the `create-plan` row from the table.
+```
+
+**Sample output — leanness finding (verbatim duplicate):**
+```
+issue: the "Cache module" section restates the `@moduledoc` for `MyApp.Cache` (lib/my_app/cache.ex) almost verbatim, creating two places to maintain the same description
+
+Replace the section with a one-line pointer:
+> See the `@moduledoc` for `MyApp.Cache` at `lib/my_app/cache.ex`.
+```
+
+**Sample output — leanness finding (pointer preferred):**
+```
+suggestion: the "Frame format" section reproduces the byte-level layout already documented in the `Wire.Frame` docstring (lib/wire/frame.ex) — full prose is defensible for quick reference, but a pointer would reduce drift
+
+Consider replacing with:
+> Frame layout is defined in the docstring of `Wire.Frame` at `lib/wire/frame.ex`.
 ```
 
 **Sample output — summary:**

--- a/.agents/skills/review-agents-md/SKILL.md
+++ b/.agents/skills/review-agents-md/SKILL.md
@@ -73,12 +73,12 @@ Is the file focused on agent guidance, or does it duplicate README/CHANGELOG con
 
 #### Leanness
 
-Does the file avoid duplicating information already present in code-level documentation (`@moduledoc`, docstrings, header comments, doc comments)? For each section that describes a specific module, type, callback, struct, byte-level layout, or symbol table, locate the corresponding code and compare wording. Apply the heuristic: *if a future agent could find this information by reading the relevant module, it should not also appear in full here — replace with a pointer*.
+Does the file avoid duplicating information already present in source-level documentation (docstrings, doc comments, header comments, or language-native annotations such as JSDoc, Rustdoc, Godoc, `@moduledoc`)? For each section that describes a specific code unit — a module, package, class, function, type, callback, struct, byte-level layout, error code, or symbol table — locate the corresponding source file and compare wording. Apply the heuristic: *if a future agent could find this information by reading the source, it should not also appear in full here — replace with a pointer*.
 
 Distinguish severities by intent:
 
 - **`suggestion`** — *pointer preferred*: section could collapse to a one-line pointer to the authoritative source, but the full prose is defensible
-- **`issue`** — *verbatim duplicate*: section repeats module docs verbatim or near-verbatim, creating two places to maintain
+- **`issue`** — *verbatim duplicate*: section repeats source documentation verbatim or near-verbatim, creating two places to maintain
 - **`issue [blocking]`** — *bloat impairs usability* (rare): accumulated duplication has grown the file to the point that an agent struggles to locate actionable guidance
 
 ### 4. Format all findings with format-review-comments
@@ -172,18 +172,18 @@ Remove the `create-plan` row from the table.
 
 **Sample output — leanness finding (verbatim duplicate):**
 ```
-issue: the "Cache module" section restates the `@moduledoc` for `MyApp.Cache` (lib/my_app/cache.ex) almost verbatim, creating two places to maintain the same description
+issue: the "Cache module" section restates the doc comment for `Cache` (src/cache.ts) almost verbatim, creating two places to maintain the same description
 
 Replace the section with a one-line pointer:
-> See the `@moduledoc` for `MyApp.Cache` at `lib/my_app/cache.ex`.
+> See the doc comment for `Cache` at `src/cache.ts`.
 ```
 
 **Sample output — leanness finding (pointer preferred):**
 ```
-suggestion: the "Frame format" section reproduces the byte-level layout already documented in the `Wire.Frame` docstring (lib/wire/frame.ex) — full prose is defensible for quick reference, but a pointer would reduce drift
+suggestion: the "Frame format" section reproduces the byte-level layout already documented in the docstring for `wire.Frame` (wire/frame.py) — full prose is defensible for quick reference, but a pointer would reduce drift
 
 Consider replacing with:
-> Frame layout is defined in the docstring of `Wire.Frame` at `lib/wire/frame.ex`.
+> Frame layout is defined in the docstring for `wire.Frame` at `wire/frame.py`.
 ```
 
 **Sample output — summary:**

--- a/.agents/skills/review-agents-md/assets/review-checklist.md
+++ b/.agents/skills/review-agents-md/assets/review-checklist.md
@@ -99,3 +99,36 @@ Is the file focused on agent guidance?
 - Content that actively misleads an agent → `issue [blocking]`
 - Content that belongs in another file → `suggestion`
 - Redundant or padded content → `nitpick`
+
+---
+
+## Dimension 6: Leanness
+
+Does the file avoid duplicating information already present in code-level documentation?
+
+> *Heuristic: if a future agent could find this information by reading the relevant module, it should not also appear in full here. Replace with a pointer.*
+
+### Detect duplication with code docs
+
+- [ ] **Identify candidate sections** — locate sections that describe specific modules, types, callbacks, structs, byte-level layouts, error codes, symbol tables, or API surfaces
+- [ ] **Locate the authoritative source** — for each candidate, find the corresponding code (use `Glob`/`Grep` to locate the module, then `Read` the file's `@moduledoc`, docstring, header comment, or doc comments)
+- [ ] **Compare wording** — check whether the AGENTS.md prose repeats the code documentation verbatim, near-verbatim, or only paraphrases the same facts
+- [ ] **Check for implementation details** — flag content that belongs in the code itself (callback contracts, struct field tables, byte-level schemas, exhaustive symbol enumerations) rather than the agent instructions
+
+### Pointer test
+
+For each candidate section, ask: *Could this section be replaced with a one-line pointer to the authoritative source without losing agent-usable information?* If yes, the section is a leanness finding.
+
+A "pointer" looks like: `See \`@moduledoc\` for \`MyApp.Foo\` at \`lib/my_app/foo.ex\`.`
+
+### Severity guidance
+
+- **`suggestion`** — *pointer preferred*: section could be a one-line pointer to code docs, but the full prose is defensible (e.g. provides agent-specific framing, summarizes for quick reference)
+- **`issue`** — *verbatim duplicate*: section repeats module docs verbatim or near-verbatim, creating two places to maintain the same information
+- **`issue [blocking]`** — *bloat impairs usability* (rare): the file has grown so large from accumulated duplication that an agent struggles to locate actionable guidance
+
+### What is not a leanness finding
+
+- Brief summaries that orient an agent before pointing to code (these aid navigation)
+- Cross-cutting conventions that span multiple modules (these have no single authoritative module to point to)
+- Workflow guidance that happens to reference module names (the focus is on the workflow, not on duplicating the module's own docs)

--- a/.agents/skills/review-agents-md/assets/review-checklist.md
+++ b/.agents/skills/review-agents-md/assets/review-checklist.md
@@ -119,7 +119,11 @@ Does the file avoid duplicating information already present in code-level docume
 
 For each candidate section, ask: *Could this section be replaced with a one-line pointer to the authoritative source without losing agent-usable information?* If yes, the section is a leanness finding.
 
-A "pointer" looks like: `See \`@moduledoc\` for \`MyApp.Foo\` at \`lib/my_app/foo.ex\`.`
+A "pointer" looks like:
+
+```
+See `@moduledoc` for `MyApp.Foo` at `lib/my_app/foo.ex`.
+```
 
 ### Severity guidance
 

--- a/.agents/skills/review-agents-md/assets/review-checklist.md
+++ b/.agents/skills/review-agents-md/assets/review-checklist.md
@@ -104,16 +104,16 @@ Is the file focused on agent guidance?
 
 ## Dimension 6: Leanness
 
-Does the file avoid duplicating information already present in code-level documentation?
+Does the file avoid duplicating information already present in source-level documentation?
 
-> *Heuristic: if a future agent could find this information by reading the relevant module, it should not also appear in full here. Replace with a pointer.*
+> *Heuristic: if a future agent could find this information by reading the source, it should not also appear in full here. Replace with a pointer.*
 
-### Detect duplication with code docs
+### Detect duplication with source documentation
 
-- [ ] **Identify candidate sections** — locate sections that describe specific modules, types, callbacks, structs, byte-level layouts, error codes, symbol tables, or API surfaces
-- [ ] **Locate the authoritative source** — for each candidate, find the corresponding code (use `Glob`/`Grep` to locate the module, then `Read` the file's `@moduledoc`, docstring, header comment, or doc comments)
-- [ ] **Compare wording** — check whether the AGENTS.md prose repeats the code documentation verbatim, near-verbatim, or only paraphrases the same facts
-- [ ] **Check for implementation details** — flag content that belongs in the code itself (callback contracts, struct field tables, byte-level schemas, exhaustive symbol enumerations) rather than the agent instructions
+- [ ] **Identify candidate sections** — locate sections that describe specific code units (modules, packages, classes, functions, types, callbacks, structs, byte-level layouts, error codes, symbol tables, or API surfaces)
+- [ ] **Locate the authoritative source** — for each candidate, find the corresponding source file (use `Glob`/`Grep`, then `Read` the file's docstring, doc comment, header comment, or language-native annotation such as JSDoc, Rustdoc, Godoc, `@moduledoc`)
+- [ ] **Compare wording** — check whether the AGENTS.md prose repeats the source documentation verbatim, near-verbatim, or only paraphrases the same facts
+- [ ] **Check for implementation details** — flag content that belongs in the source itself (callback contracts, struct field tables, byte-level schemas, exhaustive symbol enumerations) rather than the agent instructions
 
 ### Pointer test
 
@@ -122,17 +122,17 @@ For each candidate section, ask: *Could this section be replaced with a one-line
 A "pointer" looks like:
 
 ```
-See `@moduledoc` for `MyApp.Foo` at `lib/my_app/foo.ex`.
+See the doc comment for `Foo` at `src/foo.ts`.
 ```
 
 ### Severity guidance
 
-- **`suggestion`** — *pointer preferred*: section could be a one-line pointer to code docs, but the full prose is defensible (e.g. provides agent-specific framing, summarizes for quick reference)
-- **`issue`** — *verbatim duplicate*: section repeats module docs verbatim or near-verbatim, creating two places to maintain the same information
+- **`suggestion`** — *pointer preferred*: section could be a one-line pointer to source documentation, but the full prose is defensible (e.g. provides agent-specific framing, summarizes for quick reference)
+- **`issue`** — *verbatim duplicate*: section repeats source documentation verbatim or near-verbatim, creating two places to maintain the same information
 - **`issue [blocking]`** — *bloat impairs usability* (rare): the file has grown so large from accumulated duplication that an agent struggles to locate actionable guidance
 
 ### What is not a leanness finding
 
-- Brief summaries that orient an agent before pointing to code (these aid navigation)
-- Cross-cutting conventions that span multiple modules (these have no single authoritative module to point to)
-- Workflow guidance that happens to reference module names (the focus is on the workflow, not on duplicating the module's own docs)
+- Brief summaries that orient an agent before pointing to the source (these aid navigation)
+- Cross-cutting conventions that span multiple files (these have no single authoritative source to point to)
+- Workflow guidance that happens to reference symbol names (the focus is on the workflow, not on duplicating the source's own documentation)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ For full format rules, naming constraints, progressive disclosure levels, and a 
 | `format-review-comments` | apply automatically when writing any review comment, PR feedback, or critique of code | Format review and feedback comments using the Conventional Comments standard |
 | `implement-plan` | `/implement-plan` | Fetch a structured plan from a GitHub issue and orchestrate the full delivery workflow: step through unchecked tasks in dependency order, commit via create-commit, review via review-pr, validate once with lint and tests on the final state, and open a PR linked to the plan issue |
 | `refine-prose` | `/refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
-| `review-agents-md` | `/review-agents-md` | Audit AGENTS.md and equivalent agent instruction files for completeness, accuracy, agent-friendliness, freshness, and scope coherence |
+| `review-agents-md` | `/review-agents-md` | Audit AGENTS.md and equivalent agent instruction files for completeness, accuracy, agent-friendliness, freshness, scope coherence, and leanness |
 | `review-plan` | `/review-plan` | Evaluate a structured work plan across six quality dimensions: objective clarity, task actionability, dependency correctness, acceptance criteria completeness, scope appropriateness, and structural completeness |
 | `review-pr` | `/review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
 | `review-skill` | `/review-skill` | Evaluate a skill for effectiveness across instruction clarity, trigger discoverability, example completeness, composability, and scope coherence |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Reusable agent skills for Claude Code and other AI coding agents. Follows the [a
 | `format-review-comments` | applied proactively during code review | Format review and feedback comments using the Conventional Comments standard |
 | `implement-plan` | `/hax-yax:implement-plan` | Fetch a structured plan from a GitHub issue and orchestrate the full delivery workflow: step through unchecked tasks in dependency order, commit, review, validate, and open a PR |
 | `refine-prose` | `/hax-yax:refine-prose` | Polish drafted prose for clarity, conciseness, and consistent voice before presenting or posting |
-| `review-agents-md` | `/hax-yax:review-agents-md` | Audit AGENTS.md and equivalent agent instruction files for completeness, accuracy, agent-friendliness, freshness, and scope coherence |
+| `review-agents-md` | `/hax-yax:review-agents-md` | Audit AGENTS.md and equivalent agent instruction files for completeness, accuracy, agent-friendliness, freshness, scope coherence, and leanness |
 | `review-plan` | `/hax-yax:review-plan` | Evaluate a structured work plan across six quality dimensions: objective clarity, task actionability, dependency correctness, acceptance criteria completeness, scope appropriateness, and structural completeness |
 | `review-pr` | `/hax-yax:review-pr` | Conduct a systematic PR review across logic, security, performance, test coverage, and documentation |
 | `review-skill` | `/hax-yax:review-skill` | Evaluate a skill for effectiveness across instruction clarity, trigger discoverability, example completeness, composability, and scope coherence |


### PR DESCRIPTION
## Summary
- Add a sixth review dimension, **Leanness**, to `review-agents-md` that flags AGENTS.md sections duplicating code-level docs (`@moduledoc`, docstrings, header comments, doc comments).
- Extend `assets/review-checklist.md` with detection steps, the pointer-test heuristic, severity guidance, and exclusions for cases that should not produce findings.
- Update `SKILL.md` Step 3 to enumerate six dimensions and add two sample findings — verbatim duplicate (`issue`) and pointer preferred (`suggestion`).
- Refresh the skill descriptions in `AGENTS.md` and `README.md` to mention leanness alongside the existing dimensions.

## Plan
Closes #144

## Acceptance criteria
- [x] Review checklist (`assets/review-checklist.md`) includes a Leanness section
- [x] Skill instructions describe how to detect code-docs duplication
- [x] Skill produces findings in the same `conventional-comments` format as other dimensions
- [x] Leanness findings distinguish between "pointer preferred" (`suggestion`) and "verbatim duplicate" (`issue`)

## Test plan
- [ ] Lint/test step skipped — this repo has no `package.json`, `Makefile`, or other build config, and AGENTS.md does not document a lint/test convention for the Markdown-only skill library
- [ ] Spot-check rendered Markdown for the new Dimension 6 section in `assets/review-checklist.md`
- [ ] Verify the SKILL.md sample findings match the conventional-comments format used by the other dimensions
- [ ] Run `/review-agents-md` against a target file with a known module-doc duplication to confirm Leanness fires at the expected severity

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrYSW83iusy4zTFwLtkk6L)_